### PR TITLE
Misc fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{rs,script}]
+[*.rs]
 indent_size = 4
 
 [*.md]

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -6,37 +6,47 @@ pub struct Sender(());
 
 pub struct Bytes(());
 
-#[cfg(target_arch = "wasm32")]
-#[externref]
-#[link(wasm_import_module = "test")]
-extern "C" {
-    fn send_message(
-        sender: &Resource<Sender>,
-        message_ptr: *const u8,
-        message_len: usize,
-    ) -> Resource<Bytes>;
+mod imports {
+    use externref::Resource;
 
-    fn message_len(bytes: Option<&Resource<Bytes>>) -> usize;
+    use crate::{Bytes, Sender};
 
-    #[link_name = "inspect_refs"]
-    fn inspect_refs_on_host();
-}
+    #[cfg(target_arch = "wasm32")]
+    #[externref::externref]
+    #[link(wasm_import_module = "test")]
+    extern "C" {
+        pub(crate) fn send_message(
+            sender: &Resource<Sender>,
+            message_ptr: *const u8,
+            message_len: usize,
+        ) -> Resource<Bytes>;
 
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn send_message(_: &Resource<Sender>, _: *const u8, _: usize) -> Resource<Bytes> {
-    panic!("only callable from WASM")
-}
+        pub(crate) fn message_len(bytes: Option<&Resource<Bytes>>) -> usize;
 
-#[cfg(not(target_arch = "wasm32"))]
-unsafe fn message_len(_: Option<&Resource<Bytes>>) -> usize {
-    panic!("only callable from WASM")
+        #[link_name = "inspect_refs"]
+        pub(crate) fn inspect_refs_on_host();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) unsafe fn send_message(
+        _: &Resource<Sender>,
+        _: *const u8,
+        _: usize,
+    ) -> Resource<Bytes> {
+        panic!("only callable from WASM")
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) unsafe fn message_len(_: Option<&Resource<Bytes>>) -> usize {
+        panic!("only callable from WASM")
+    }
 }
 
 /// Calls to the host to check the `externrefs` table.
 fn inspect_refs() {
     #[cfg(target_arch = "wasm32")]
     unsafe {
-        inspect_refs_on_host();
+        imports::inspect_refs_on_host();
     }
 }
 
@@ -46,7 +56,7 @@ pub extern "C" fn test_export(sender: Resource<Sender>) {
         .into_iter()
         .map(|message| {
             inspect_refs();
-            unsafe { send_message(&sender, message.as_ptr(), message.len()) }
+            unsafe { imports::send_message(&sender, message.as_ptr(), message.len()) }
         });
     let mut messages: Vec<_> = messages.collect();
     inspect_refs();
@@ -60,8 +70,8 @@ pub extern "C" fn test_export(sender: Resource<Sender>) {
 pub extern "C" fn test_nulls(sender: Option<&Resource<Sender>>) {
     let message = "test";
     if let Some(sender) = sender {
-        let bytes = unsafe { send_message(sender, message.as_ptr(), message.len()) };
-        assert_eq!(unsafe { message_len(Some(&bytes)) }, 4);
+        let bytes = unsafe { imports::send_message(sender, message.as_ptr(), message.len()) };
+        assert_eq!(unsafe { imports::message_len(Some(&bytes)) }, 4);
     }
-    assert_eq!(unsafe { message_len(None) }, 0);
+    assert_eq!(unsafe { imports::message_len(None) }, 0);
 }

--- a/src/processor/error.rs
+++ b/src/processor/error.rs
@@ -32,13 +32,6 @@ pub enum Error {
     Read(ReadError),
     /// Error parsing the WASM module.
     Wasm(anyhow::Error),
-    /// Missing imported function with the enclosed module / name.
-    NoImport {
-        /// Name of the module.
-        module: String,
-        /// Name of the function.
-        name: String,
-    },
     /// Unexpected type of an import (expected a function).
     UnexpectedImportType {
         /// Name of the module.
@@ -80,13 +73,6 @@ impl fmt::Display for Error {
             Self::Read(err) => write!(formatter, "failed reading WASM custom section: {}", err),
             Self::Wasm(err) => write!(formatter, "failed reading WASM module: {}", err),
 
-            Self::NoImport { module, name } => {
-                write!(
-                    formatter,
-                    "missing imported function `{}::{}`",
-                    module, name
-                )
-            }
             Self::UnexpectedImportType { module, name } => {
                 write!(
                     formatter,

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -105,9 +105,7 @@ impl<'a> Processor<'a> {
 
         let state = ProcessingState::new(module, self)?;
         state.replace_functions(module);
-        for function in &functions {
-            ProcessingState::process_function(function, module)?;
-        }
+        state.process_functions(&functions, module)?;
 
         gc::run(module);
         Ok(())

--- a/src/processor/state.rs
+++ b/src/processor/state.rs
@@ -1,11 +1,14 @@
 //! Stateful WASM module processing.
 
 use walrus::{
-    ir, ExportItem, FunctionBuilder, FunctionId, ImportKind, LocalId, Module, ModuleTypes, TypeId,
-    ValType,
+    ir, ExportItem, FunctionBuilder, FunctionId, ImportKind, LocalFunction, LocalId, Module,
+    ModuleLocals, ModuleTypes, TypeId, ValType,
 };
 
-use std::{collections::HashMap, mem};
+use std::{
+    collections::{HashMap, HashSet},
+    iter, mem,
+};
 
 use super::{
     functions::{ExternrefImports, PatchedFunctions},
@@ -40,38 +43,89 @@ impl ProcessingState {
         self.patched_fns.replace_calls(module);
     }
 
-    pub fn process_function(function: &Function<'_>, module: &mut Module) -> Result<(), Error> {
-        match function.kind {
+    pub fn process_functions(
+        &self,
+        functions: &[Function<'_>],
+        module: &mut Module,
+    ) -> Result<(), Error> {
+        // First, resolve function IDs for exports / imports.
+        let function_ids: Result<Vec<_>, _> = functions
+            .iter()
+            .map(|function| Self::function_id(function, module))
+            .collect();
+        let function_ids = function_ids?;
+
+        // Determine which functions return externrefs (only patched imports or exports can
+        // do that).
+        let mut functions_returning_ref = HashSet::new();
+        if let Some(fn_id) = self.patched_fns.get_ref_id() {
+            functions_returning_ref.insert(fn_id);
+        }
+
+        for (function, &fn_id) in functions.iter().zip(&function_ids) {
+            if let Some(fn_id) = fn_id {
+                let type_id = module.funcs.get(fn_id).ty();
+                let results_len = module.types.get(type_id).results().len();
+                let refs = &function.externrefs;
+                if results_len == 1 && refs.is_set(refs.bit_len() - 1) {
+                    functions_returning_ref.insert(fn_id);
+                }
+
+                #[cfg_attr(not(feature = "processor-log"), allow(unused_variables))]
+                if let FunctionKind::Import(module_name) = function.kind {
+                    #[cfg(feature = "processor-log")]
+                    log::info!(
+                        target: "externref",
+                        "Patching imported function `{}` from module `{}`",
+                        function.name, module_name
+                    );
+                    transform_imported_fn(module, function, fn_id)?;
+                }
+            }
+        }
+
+        let functions_by_id = function_ids
+            .into_iter()
+            .zip(functions)
+            .filter_map(|(fn_id, function)| fn_id.map(|fn_id| (fn_id, function)));
+        let functions_by_id: HashMap<_, _> = functions_by_id.collect();
+
+        let local_fn_ids: Vec<_> = module.funcs.iter_local().map(|(id, _)| id).collect();
+        for fn_id in local_fn_ids {
+            if let Some(function) = functions_by_id.get(&fn_id) {
+                Self::transform_export(module, &functions_returning_ref, fn_id, function)?;
+            } else {
+                Self::transform_local_fn(module, &functions_returning_ref, fn_id);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn function_id(function: &Function<'_>, module: &Module) -> Result<Option<FunctionId>, Error> {
+        Ok(Some(match function.kind {
             FunctionKind::Export => {
                 let export = module
                     .exports
                     .iter()
                     .find(|export| export.name == function.name);
                 let export = export.ok_or_else(|| Error::NoExport(function.name.to_owned()))?;
-                let fn_id = match &export.item {
+                match &export.item {
                     ExportItem::Function(fn_id) => *fn_id,
                     _ => return Err(Error::UnexpectedExportType(function.name.to_owned())),
-                };
-                Self::transform_local_fn(module, fn_id, function)?;
+                }
             }
 
             FunctionKind::Import(module_name) => {
-                #[cfg(feature = "processor-log")]
-                log::info!(
-                    target: "externref",
-                    "Patching imported function `{}` from module `{}`",
-                    function.name, module_name
-                );
-
                 let import_id = match module.imports.find(module_name, function.name) {
                     Some(id) => id,
                     None => {
                         // The function is declared, but not actually used from the module.
                         // This is fine for us.
-                        return Ok(());
+                        return Ok(None);
                     }
                 };
-                let fn_id = match module.imports.get(import_id).kind {
+                match module.imports.get(import_id).kind {
                     ImportKind::Function(fn_id) => fn_id,
                     _ => {
                         return Err(Error::UnexpectedImportType {
@@ -79,16 +133,15 @@ impl ProcessingState {
                             name: function.name.to_owned(),
                         })
                     }
-                };
-                transform_imported_fn(module, function, fn_id)?;
+                }
             }
-        }
-
-        Ok(())
+        }))
     }
 
-    fn transform_local_fn(
+    #[allow(clippy::needless_collect)] // false positive
+    fn transform_export(
         module: &mut Module,
+        functions_returning_ref: &HashSet<FunctionId>,
         fn_id: FunctionId,
         function: &Function<'_>,
     ) -> Result<(), Error> {
@@ -102,106 +155,156 @@ impl ProcessingState {
         for idx in function.externrefs.set_indices() {
             if let Some(arg) = local_fn.args.get_mut(idx) {
                 let new_local = module.locals.add(ValType::Externref);
-                locals_mapping.insert(*arg, new_local);
+                locals_mapping.insert(new_local, *arg);
                 *arg = new_local;
             }
         }
+        let ref_args: Vec<_> = locals_mapping.keys().copied().collect();
+
+        let mut calls_visitor = RefCallDetector {
+            locals: &mut module.locals,
+            functions_returning_ref,
+            new_locals: HashMap::default(),
+        };
+        ir::dfs_pre_order_mut(&mut calls_visitor, local_fn, local_fn.entry_block());
+        let mut new_locals = calls_visitor.new_locals;
+        new_locals.extend(locals_mapping);
 
         // Determine which `local.get $arg` instructions must be replaced with new arg locals.
-        let mut locals_visitor = ReplaceLocals::new(locals_mapping.keys().copied());
+        let mut locals_visitor = LocalReplacementCounter::new(ref_args.into_iter(), new_locals);
         ir::dfs_in_order(&mut locals_visitor, local_fn, local_fn.entry_block());
+        let mut replacer = LocalReplacer::from(locals_visitor);
         // Clone the function with new function types.
-        let mut visitor =
-            CloneFunction::new(FunctionBuilder::new(&mut module.types, &params, &results));
-        ir::dfs_in_order(&mut visitor, local_fn, local_fn.entry_block());
+        let mut cloner =
+            FunctionCloner::new(FunctionBuilder::new(&mut module.types, &params, &results));
+        ir::dfs_in_order(&mut cloner, local_fn, local_fn.entry_block());
+        cloner.clone_function(local_fn, &mut replacer);
 
-        // We cannot use `VisitorMut` here because we're switching arenas for `InstrSeqId`s.
-        for (old_id, new_id) in &visitor.sequence_mapping {
-            let seq = local_fn.block_mut(*old_id);
-            let mut instructions = mem::take(&mut seq.instrs);
-            for (instr, _) in &mut instructions {
-                match instr {
-                    ir::Instr::Block(ir::Block { seq })
-                    | ir::Instr::Loop(ir::Loop { seq })
-                    | ir::Instr::Br(ir::Br { block: seq })
-                    | ir::Instr::BrIf(ir::BrIf { block: seq }) => {
-                        *seq = visitor.sequence_mapping[seq];
-                    }
+        Ok(())
+    }
 
-                    ir::Instr::IfElse(ir::IfElse {
-                        consequent,
-                        alternative,
-                    }) => {
-                        *consequent = visitor.sequence_mapping[consequent];
-                        *alternative = visitor.sequence_mapping[alternative];
-                    }
-                    ir::Instr::BrTable(ir::BrTable { blocks, default }) => {
-                        for block in blocks.iter_mut() {
-                            *block = visitor.sequence_mapping[block];
-                        }
-                        *default = visitor.sequence_mapping[default];
-                    }
+    fn transform_local_fn(
+        module: &mut Module,
+        functions_returning_ref: &HashSet<FunctionId>,
+        fn_id: FunctionId,
+    ) {
+        let local_fn = module.funcs.get_mut(fn_id).kind.unwrap_local_mut();
 
-                    ir::Instr::LocalGet(ir::LocalGet { local }) => {
-                        if locals_visitor.should_replace(*old_id, *local) {
-                            *local = locals_mapping[local];
-                        }
-                    }
-
-                    _ => { /* Do nothing */ }
-                }
-            }
-
-            *visitor.builder.instr_seq(*new_id).instrs_mut() = instructions;
+        let mut calls_visitor = RefCallDetector {
+            locals: &mut module.locals,
+            functions_returning_ref,
+            new_locals: HashMap::default(),
+        };
+        ir::dfs_pre_order_mut(&mut calls_visitor, local_fn, local_fn.entry_block());
+        let new_locals = calls_visitor.new_locals;
+        if new_locals.is_empty() {
+            // No new locals are introduced by calls; the function doesn't need
+            // to be transformed.
+            return;
         }
 
-        *local_fn.builder_mut() = visitor.builder;
-        Ok(())
+        // Determine which `local.get $arg` instructions must be replaced with new arg locals.
+        let mut locals_visitor = LocalReplacementCounter::new(iter::empty(), new_locals);
+        ir::dfs_in_order(&mut locals_visitor, local_fn, local_fn.entry_block());
+        let mut replacer = LocalReplacer::from(locals_visitor);
+        ir::dfs_pre_order_mut(&mut replacer, local_fn, local_fn.entry_block());
+    }
+}
+
+/// Visitor to detect calls to functions returning `externref`s and create a new ref local
+/// for each call.
+#[derive(Debug)]
+struct RefCallDetector<'a> {
+    locals: &'a mut ModuleLocals,
+    functions_returning_ref: &'a HashSet<FunctionId>,
+    /// Mapping from a new local to the old local.
+    new_locals: HashMap<LocalId, LocalId>,
+}
+
+impl RefCallDetector<'_> {
+    fn returns_ref(&self, instr: &ir::Instr) -> bool {
+        if let ir::Instr::Call(call) = instr {
+            self.functions_returning_ref.contains(&call.func)
+        } else {
+            false
+        }
+    }
+
+    fn replace_local(&mut self, local: &mut LocalId) {
+        let new_local = self.locals.add(ValType::Externref);
+        self.new_locals.insert(new_local, *local);
+        *local = new_local;
+    }
+}
+
+impl ir::VisitorMut for RefCallDetector<'_> {
+    fn start_instr_seq_mut(&mut self, instr_seq: &mut ir::InstrSeq) {
+        let mut ref_on_top_of_stack = false;
+        for (instr, _) in &mut instr_seq.instrs {
+            match instr {
+                ir::Instr::LocalSet(local_set) if ref_on_top_of_stack => {
+                    self.replace_local(&mut local_set.local);
+                    ref_on_top_of_stack = false;
+                }
+                ir::Instr::LocalTee(local_tee) if ref_on_top_of_stack => {
+                    self.replace_local(&mut local_tee.local);
+                }
+                _ => {
+                    ref_on_top_of_stack = self.returns_ref(instr);
+                }
+            }
+        }
     }
 }
 
 #[derive(Debug, Default)]
 struct LocalState {
-    seq_counts: HashMap<ir::InstrSeqId, usize>,
-    reassigned: bool,
+    replacements: HashMap<ir::InstrSeqId, Vec<Option<LocalId>>>,
+    current_replacement: Option<LocalId>,
 }
 
-/// Visitor replacing mentions of `externref` args of patched functions.
+/// Visitor counting mentions of `externref` locals in patched functions.
 ///
 /// It is valid to reassign param locals via `local.set` or `local.tee`
 /// (and Rust frequently does this in practice).
 /// Since we change the local type from `i32` to `externref`, we need to track reassignments,
 /// and not change the local ID after reassignment (since it should retain the old `i32` type).
 #[derive(Debug)]
-struct ReplaceLocals {
+struct LocalReplacementCounter {
     locals: HashMap<LocalId, LocalState>,
+    new_locals: HashMap<LocalId, LocalId>,
     current_seqs: Vec<ir::InstrSeqId>,
 }
 
-impl ReplaceLocals {
-    fn new(locals: impl Iterator<Item = LocalId>) -> Self {
+impl LocalReplacementCounter {
+    fn new(ref_args: impl Iterator<Item = LocalId>, new_locals: HashMap<LocalId, LocalId>) -> Self {
+        let mut locals: HashMap<_, _> = new_locals
+            .values()
+            .map(|local_id| (*local_id, LocalState::default()))
+            .collect();
+        for arg in ref_args {
+            let old_local = new_locals[&arg];
+            locals.get_mut(&old_local).unwrap().current_replacement = Some(arg);
+        }
+
         Self {
-            locals: locals
-                .map(|local_id| (local_id, LocalState::default()))
-                .collect(),
+            locals,
+            new_locals,
             current_seqs: vec![],
         }
     }
 
-    fn should_replace(&mut self, seq: ir::InstrSeqId, local: LocalId) -> bool {
+    fn visit_assignment(&mut self, local: LocalId) {
         if let Some(state) = self.locals.get_mut(&local) {
-            if let Some(count) = state.seq_counts.get_mut(&seq) {
-                if *count > 0 {
-                    *count -= 1;
-                    return true;
-                }
-            }
+            state.current_replacement = None;
+        } else if let Some(old_local) = self.new_locals.get(&local) {
+            let state = self.locals.get_mut(old_local).unwrap();
+            state.current_replacement = Some(local);
         }
-        false
     }
 }
 
-impl ir::Visitor<'_> for ReplaceLocals {
+impl ir::Visitor<'_> for LocalReplacementCounter {
     fn start_instr_seq(&mut self, instr_seq: &ir::InstrSeq) {
         self.current_seqs.push(instr_seq.id());
     }
@@ -210,45 +313,140 @@ impl ir::Visitor<'_> for ReplaceLocals {
         self.current_seqs.pop();
     }
 
-    fn visit_local_id(&mut self, local_id: &LocalId) {
+    fn visit_local_get(&mut self, instr: &ir::LocalGet) {
+        let local_id = instr.local;
         let current_seq = *self.current_seqs.last().unwrap();
-        if let Some(state) = self.locals.get_mut(local_id) {
-            if !state.reassigned {
-                *state.seq_counts.entry(current_seq).or_insert(0) += 1;
-            }
+        if let Some(state) = self.locals.get_mut(&local_id) {
+            state
+                .replacements
+                .entry(current_seq)
+                .or_default()
+                .push(state.current_replacement);
         }
     }
 
     fn visit_local_set(&mut self, instr: &ir::LocalSet) {
-        if let Some(state) = self.locals.get_mut(&instr.local) {
-            state.reassigned = true;
-        }
+        self.visit_assignment(instr.local);
     }
 
     fn visit_local_tee(&mut self, instr: &ir::LocalTee) {
-        if let Some(state) = self.locals.get_mut(&instr.local) {
-            state.reassigned = true;
+        self.visit_assignment(instr.local);
+    }
+}
+
+#[derive(Debug)]
+struct LocalReplacer {
+    locals: HashMap<LocalId, LocalState>,
+    current_seqs: Vec<ir::InstrSeqId>,
+}
+
+impl LocalReplacer {
+    fn take_replacement(&mut self, seq: ir::InstrSeqId, local: LocalId) -> Option<LocalId> {
+        if let Some(state) = self.locals.get_mut(&local) {
+            if let Some(replacements) = state.replacements.get_mut(&seq) {
+                return replacements.pop().flatten();
+            }
+        }
+        None
+    }
+}
+
+impl From<LocalReplacementCounter> for LocalReplacer {
+    fn from(counter: LocalReplacementCounter) -> Self {
+        // Reverse all replacements to pop them in `Self::take_replacement()` in proper order.
+        let mut locals = counter.locals;
+        for state in locals.values_mut() {
+            for replacements in state.replacements.values_mut() {
+                replacements.reverse();
+            }
+        }
+
+        Self {
+            locals,
+            current_seqs: vec![],
+        }
+    }
+}
+
+impl ir::VisitorMut for LocalReplacer {
+    fn start_instr_seq_mut(&mut self, instr_seq: &mut ir::InstrSeq) {
+        self.current_seqs.push(instr_seq.id());
+    }
+
+    fn end_instr_seq_mut(&mut self, _: &mut ir::InstrSeq) {
+        self.current_seqs.pop();
+    }
+
+    fn visit_local_get_mut(&mut self, instr: &mut ir::LocalGet) {
+        let seq = self.current_seqs.last().unwrap();
+        if let Some(replacement) = self.take_replacement(*seq, instr.local) {
+            instr.local = replacement;
         }
     }
 }
 
 /// Visitor for function cloning.
 #[derive(Debug)]
-struct CloneFunction {
+struct FunctionCloner {
     builder: FunctionBuilder,
     sequence_mapping: HashMap<ir::InstrSeqId, ir::InstrSeqId>,
 }
 
-impl CloneFunction {
+impl FunctionCloner {
     fn new(builder: FunctionBuilder) -> Self {
         Self {
             builder,
             sequence_mapping: HashMap::new(),
         }
     }
+
+    fn clone_function(self, local_fn: &mut LocalFunction, replacer: &mut LocalReplacer) {
+        let mut builder = self.builder;
+        // We cannot use `VisitorMut` here because we're switching arenas for `InstrSeqId`s.
+        for (old_id, new_id) in &self.sequence_mapping {
+            let seq = local_fn.block_mut(*old_id);
+            let mut instructions = mem::take(&mut seq.instrs);
+            for (instr, _) in &mut instructions {
+                match instr {
+                    ir::Instr::Block(ir::Block { seq })
+                    | ir::Instr::Loop(ir::Loop { seq })
+                    | ir::Instr::Br(ir::Br { block: seq })
+                    | ir::Instr::BrIf(ir::BrIf { block: seq }) => {
+                        *seq = self.sequence_mapping[seq];
+                    }
+
+                    ir::Instr::IfElse(ir::IfElse {
+                        consequent,
+                        alternative,
+                    }) => {
+                        *consequent = self.sequence_mapping[consequent];
+                        *alternative = self.sequence_mapping[alternative];
+                    }
+                    ir::Instr::BrTable(ir::BrTable { blocks, default }) => {
+                        for block in blocks.iter_mut() {
+                            *block = self.sequence_mapping[block];
+                        }
+                        *default = self.sequence_mapping[default];
+                    }
+
+                    ir::Instr::LocalGet(ir::LocalGet { local }) => {
+                        if let Some(new_local) = replacer.take_replacement(*old_id, *local) {
+                            *local = new_local;
+                        }
+                    }
+
+                    _ => { /* Do nothing */ }
+                }
+            }
+
+            *builder.instr_seq(*new_id).instrs_mut() = instructions;
+        }
+
+        *local_fn.builder_mut() = builder;
+    }
 }
 
-impl ir::Visitor<'_> for CloneFunction {
+impl ir::Visitor<'_> for FunctionCloner {
     fn start_instr_seq(&mut self, instr_seq: &ir::InstrSeq) {
         let new_id = if self.sequence_mapping.is_empty() {
             // entry block
@@ -332,5 +530,81 @@ fn fn_module<'a>(fn_kind: &FunctionKind<'a>) -> Option<&'a str> {
     match fn_kind {
         FunctionKind::Export => None,
         FunctionKind::Import(module) => Some(*module),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detecting_calls_to_functions_returning_ref() {
+        const MODULE_BYTES: &[u8] = br#"
+            (module
+                (import "test" "function" (func $get_ref (result i32)))
+
+                (func (export "test") (param $ref i32)
+                    (local $x i32)
+                    (local.set $x (local.get $ref)) ;; new local not required
+                    (local.set $x (call $get_ref)) ;; new local required
+                    (drop (local.get $x)) ;; new local used
+                    (drop (local.tee $x (local.get $ref))) ;; existing local $x should be used
+                    (drop (local.get $x))
+                    (drop (call $get_ref))
+                )
+            )
+        "#;
+
+        let module = wat::parse_bytes(MODULE_BYTES).unwrap();
+        let mut module = Module::from_buffer(&module).unwrap();
+        let functions_returning_ref: HashSet<_> = module
+            .funcs
+            .iter()
+            .filter_map(|function| {
+                if matches!(&function.kind, walrus::FunctionKind::Import(_)) {
+                    Some(function.id())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let fn_id = module.exports.iter().find_map(|export| {
+            if export.name == "test" {
+                Some(export.item)
+            } else {
+                None
+            }
+        });
+        let fn_id = match fn_id.unwrap() {
+            ExportItem::Function(fn_id) => fn_id,
+            _ => unreachable!(),
+        };
+
+        ProcessingState::transform_local_fn(&mut module, &functions_returning_ref, fn_id);
+
+        let ref_locals: Vec<_> = module
+            .locals
+            .iter()
+            .filter(|local| local.ty() == ValType::Externref)
+            .collect();
+        assert_eq!(ref_locals.len(), 1, "{:?}", ref_locals);
+        let ref_local_id = ref_locals[0].id();
+
+        let local_fn = module.funcs.get(fn_id).kind.unwrap_local();
+        let mut mentions = LocalMentions::default();
+        ir::dfs_in_order(&mut mentions, local_fn, local_fn.entry_block());
+        assert_eq!(mentions.local_counts[&ref_local_id], 2);
+    }
+
+    #[derive(Debug, Default)]
+    struct LocalMentions {
+        local_counts: HashMap<LocalId, usize>,
+    }
+
+    impl ir::Visitor<'_> for LocalMentions {
+        fn visit_local_id(&mut self, local_id: &LocalId) {
+            *self.local_counts.entry(*local_id).or_default() += 1;
+        }
     }
 }

--- a/src/processor/state.rs
+++ b/src/processor/state.rs
@@ -63,14 +63,14 @@ impl ProcessingState {
                     function.name, module_name
                 );
 
-                let import_id =
-                    module
-                        .imports
-                        .find(module_name, function.name)
-                        .ok_or_else(|| Error::NoImport {
-                            module: module_name.to_owned(),
-                            name: function.name.to_owned(),
-                        })?;
+                let import_id = match module.imports.find(module_name, function.name) {
+                    Some(id) => id,
+                    None => {
+                        // The function is declared, but not actually used from the module.
+                        // This is fine for us.
+                        return Ok(());
+                    }
+                };
                 let fn_id = match module.imports.get(import_id).kind {
                     ImportKind::Function(fn_id) => fn_id,
                     _ => {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -58,7 +58,8 @@ impl<'a> BitSlice<'a> {
         self.bit_len
     }
 
-    fn is_set(&self, idx: usize) -> bool {
+    /// Checks if a bit with the specified 0-based index is set.
+    pub fn is_set(&self, idx: usize) -> bool {
         if idx > self.bit_len {
             return false;
         }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -34,7 +34,7 @@ impl<const BYTES: usize> BitSliceBuilder<BYTES> {
 // Why invent a new type? Turns out that existing implementations (e.g., `bv` and `bitvec`)
 // cannot be used in const contexts.
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct BitSlice<'a> {
     bytes: &'a [u8],
     bit_len: usize,
@@ -125,7 +125,7 @@ fn read_str<'a>(buffer: &mut &'a [u8], context: &str) -> Result<&'a str, ReadErr
 
 /// Kind of a function with [`Resource`](crate::Resource) args or return type.
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum FunctionKind<'a> {
     /// Function exported from a WASM module.
     Export,
@@ -182,7 +182,7 @@ impl<'a> FunctionKind<'a> {
 ///
 /// [post-processing]: crate::processor
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct Function<'a> {
     /// Kind of this function.
     pub kind: FunctionKind<'a>,

--- a/tests/modules/simple-no-inline.wast
+++ b/tests/modules/simple-no-inline.wast
@@ -1,0 +1,58 @@
+(module
+  ;; Corresponds to the following logic:
+  ;;
+  ;; ```
+  ;; extern "C" {
+  ;;     fn alloc(arena: &Resource<Arena>, cap: usize)
+  ;;         -> Option<Resource<Bytes>>;
+  ;; }
+  ;;
+  ;; pub extern "C" fn test(arena: &Resource<Arena>) {
+  ;;     let _bytes = unsafe { alloc(arena, 42) }.unwrap();
+  ;; }
+  ;; ```
+  ;;
+  ;; Unlike with the module in `simple.wast`, we don't inline some assignments
+  ;; from functions returning `externref`s in order to test that the corresponding
+  ;; locals are transformed.
+
+  ;; surrogate imports
+  (import "externref" "insert" (func $insert_ref (param i32) (result i32)))
+  (import "externref" "get" (func $get_ref (param i32) (result i32)))
+  (import "externref" "drop" (func $drop_ref (param i32)))
+  ;; real imported fn
+  (import "arena" "alloc" (func $alloc (param i32 i32) (result i32)))
+
+  ;; exported fn
+  (func (export "test") (param $arena i32)
+    (local $bytes i32)
+    (local.set $bytes
+      (call $alloc
+        (call $get_ref
+          (local.tee $arena
+            (call $insert_ref (local.get $arena))
+          )
+        )
+        (i32.const 42)
+      )
+    )
+    (if (i32.eq
+      (local.tee $bytes
+        (call $insert_ref (local.get $bytes))
+      )
+      (i32.const -1))
+      (then (unreachable))
+      (else (call $drop_ref (local.get $bytes)))
+   )
+   (call $drop_ref (local.get $arena))
+  )
+
+  ;; internal fn; the `ref` local should be transformed as well
+  (func (param $index i32)
+    (local $ref i32)
+    (local.set $ref
+      (call $get_ref (local.get $index))
+    )
+    (call $drop_ref (local.get $ref))
+  )
+)


### PR DESCRIPTION
Various fixes for correctness issues that could lead to invalid transformed modules (e.g., if there were locals for results of functions returning `externref`).