### PR TITLE
Post-release updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix an incorrect conditional compilation attr for a tracing event
+  in the processor module.
+
 ## 0.1.0 - 2022-10-29
 
 The initial release of `externref`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ maintenance = { status = "experimental" }
 externref-macro = { version = "0.1.0", path = "crates/macro", optional = true }
 # Processor dependencies
 anyhow = { version = "1.0.58", optional = true }
+walrus = { version = "0.19.0", optional = true }
 # Enables tracing during module processing
 tracing = { version = "0.1.37", optional = true }
-walrus = { version = "0.19.0", optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3.3"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/externref#license)
 ![rust 1.60+ required](https://img.shields.io/badge/rust-1.60+-blue.svg?label=Required%20Rust)
 
-**Documentation:**
+**Documentation:** [![Docs.rs](https://docs.rs/externref/badge.svg)](https://docs.rs/externref/)
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/externref/externref/)
 
 A [reference type] (aka `externref` or `anyref`) is an opaque reference made available to

--- a/crates/macro/CHANGELOG.md
+++ b/crates/macro/CHANGELOG.md
@@ -1,0 +1,1 @@
+../../CHANGELOG.md

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -24,4 +24,5 @@ quote = "1.0"
 syn = "1.0"
 
 [dev-dependencies]
+trybuild = "1.0.71"
 version-sync = "0.9.4"

--- a/crates/macro/README.md
+++ b/crates/macro/README.md
@@ -4,7 +4,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/externref#license)
 ![rust 1.60+ required](https://img.shields.io/badge/rust-1.60+-blue.svg?label=Required%20Rust)
 
-**Documentation:**
+**Documentation:** [![Docs.rs](https://docs.rs/externref-macro/badge.svg)](https://docs.rs/externref-macro/)
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/externref/externref_macro/)
 
 This macro complements the [`externref`] library, wrapping imported or exported functions

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -20,7 +20,7 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use syn::Item;
+use syn::{parse::Error as SynError, Item};
 
 mod externref;
 
@@ -48,10 +48,9 @@ pub fn externref(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let output = match syn::parse::<Item>(input) {
         Ok(Item::ForeignMod(mut module)) => for_foreign_module(&mut module),
         Ok(Item::Fn(mut function)) => for_export(&mut function),
-        Ok(other_item) => {
-            return darling::Error::custom(MSG)
-                .with_span(&other_item)
-                .write_errors()
+        Ok(other) => {
+            return SynError::new_spanned(other, MSG)
+                .into_compile_error()
                 .into()
         }
         Err(err) => return err.into_compile_error().into(),

--- a/crates/macro/tests/integration.rs
+++ b/crates/macro/tests/integration.rs
@@ -1,0 +1,7 @@
+//! UI tests for various compilation failures.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/crates/macro/tests/ui/fn_with_bogus_export_name.rs
+++ b/crates/macro/tests/ui/fn_with_bogus_export_name.rs
@@ -1,0 +1,15 @@
+use externref_macro::externref;
+
+#[externref]
+#[export_name("what")]
+pub extern "C" fn bogus() {
+    // Do nothing
+}
+
+#[externref]
+#[export_name = 10]
+pub extern "C" fn bogus_too() {
+    // Do nothing
+}
+
+fn main() {}

--- a/crates/macro/tests/ui/fn_with_bogus_export_name.stderr
+++ b/crates/macro/tests/ui/fn_with_bogus_export_name.stderr
@@ -1,0 +1,11 @@
+error: Unexpected `export_name` attribute format; expected a name-value pair
+ --> tests/ui/fn_with_bogus_export_name.rs:4:1
+  |
+4 | #[export_name("what")]
+  | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Unexpected `export_name` value; expected a string
+  --> tests/ui/fn_with_bogus_export_name.rs:10:1
+   |
+10 | #[export_name = 10]
+   | ^^^^^^^^^^^^^^^^^^^

--- a/crates/macro/tests/ui/item_with_bogus_abi.rs
+++ b/crates/macro/tests/ui/item_with_bogus_abi.rs
@@ -1,0 +1,13 @@
+use externref_macro::externref;
+
+#[externref]
+pub extern "win64" fn test() {
+    // Does nothing.
+}
+
+#[externref]
+extern "win64" {
+    pub fn unused(ptr: *const u8, len: usize);
+}
+
+fn main() {}

--- a/crates/macro/tests/ui/item_with_bogus_abi.stderr
+++ b/crates/macro/tests/ui/item_with_bogus_abi.stderr
@@ -1,0 +1,11 @@
+error: Unexpected ABI win64 for exported function; expected `C`
+ --> tests/ui/item_with_bogus_abi.rs:4:12
+  |
+4 | pub extern "win64" fn test() {
+  |            ^^^^^^^
+
+error: Unexpected ABI win64 for foreign module; expected `C`
+ --> tests/ui/item_with_bogus_abi.rs:9:8
+  |
+9 | extern "win64" {
+  |        ^^^^^^^

--- a/crates/macro/tests/ui/item_without_abi.rs
+++ b/crates/macro/tests/ui/item_without_abi.rs
@@ -1,0 +1,13 @@
+use externref_macro::externref;
+
+#[externref]
+pub fn test() {
+    // Does nothing.
+}
+
+#[externref]
+extern {
+    pub fn unused(ptr: *const u8, len: usize);
+}
+
+fn main() {}

--- a/crates/macro/tests/ui/item_without_abi.stderr
+++ b/crates/macro/tests/ui/item_without_abi.stderr
@@ -1,0 +1,11 @@
+error: exported function must be marked with `extern "C"`
+ --> tests/ui/item_without_abi.rs:4:5
+  |
+4 | pub fn test() {
+  |     ^^^^^^^^^
+
+error: foreign module must be marked with `extern "C"`
+ --> tests/ui/item_without_abi.rs:9:1
+  |
+9 | extern {
+  | ^^^^^^

--- a/crates/macro/tests/ui/module_with_bogus_link_name.rs
+++ b/crates/macro/tests/ui/module_with_bogus_link_name.rs
@@ -1,0 +1,17 @@
+use externref_macro::externref;
+
+#[externref]
+#[link(wasm_import_module = "test")]
+extern "C" {
+    #[link_name("huh")]
+    pub fn unused(ptr: *const u8, len: usize);
+}
+
+#[externref]
+#[link(wasm_import_module = "test")]
+extern "C" {
+    #[link_name = 3]
+    pub fn other(ptr: *const u8, len: usize);
+}
+
+fn main() {}

--- a/crates/macro/tests/ui/module_with_bogus_link_name.stderr
+++ b/crates/macro/tests/ui/module_with_bogus_link_name.stderr
@@ -1,0 +1,11 @@
+error: Unexpected `link_name` attribute format; expected a name-value pair
+ --> tests/ui/module_with_bogus_link_name.rs:6:5
+  |
+6 |     #[link_name("huh")]
+  |     ^^^^^^^^^^^^^^^^^^^
+
+error: Unexpected `link_name` value; expected a string
+  --> tests/ui/module_with_bogus_link_name.rs:13:5
+   |
+13 |     #[link_name = 3]
+   |     ^^^^^^^^^^^^^^^^

--- a/crates/macro/tests/ui/module_with_bogus_name.rs
+++ b/crates/macro/tests/ui/module_with_bogus_name.rs
@@ -1,0 +1,21 @@
+use externref_macro::externref;
+
+#[externref]
+#[link = 5]
+extern "C" {
+    pub fn unused(ptr: *const u8, len: usize);
+}
+
+#[externref]
+#[link(wasm_module = "what")]
+extern "C" {
+    pub fn unused(ptr: *const u8, len: usize);
+}
+
+#[externref]
+#[link(wasm_import_module = 5)]
+extern "C" {
+    pub fn unused(ptr: *const u8, len: usize);
+}
+
+fn main() {}

--- a/crates/macro/tests/ui/module_with_bogus_name.stderr
+++ b/crates/macro/tests/ui/module_with_bogus_name.stderr
@@ -1,0 +1,17 @@
+error: Unexpected contents of `#[link(..)]` attr (expected a list of name-value pairs)
+ --> tests/ui/module_with_bogus_name.rs:4:1
+  |
+4 | #[link = 5]
+  | ^^^^^^^^^^^
+
+error: #[link(wasm_import_module = "..")] must be specified on the foreign module
+  --> tests/ui/module_with_bogus_name.rs:10:1
+   |
+10 | #[link(wasm_module = "what")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Unexpected WASM module name format (expected a string)
+  --> tests/ui/module_with_bogus_name.rs:16:29
+   |
+16 | #[link(wasm_import_module = 5)]
+   |                             ^

--- a/crates/macro/tests/ui/module_without_name.rs
+++ b/crates/macro/tests/ui/module_without_name.rs
@@ -1,0 +1,8 @@
+use externref_macro::externref;
+
+#[externref]
+extern "C" {
+    pub fn unused(ptr: *const u8, len: usize);
+}
+
+fn main() {}

--- a/crates/macro/tests/ui/module_without_name.stderr
+++ b/crates/macro/tests/ui/module_without_name.stderr
@@ -1,0 +1,7 @@
+error: #[link(wasm_import_module = "..")] must be specified on the foreign module
+ --> tests/ui/module_without_name.rs:4:1
+  |
+4 | / extern "C" {
+5 | |     pub fn unused(ptr: *const u8, len: usize);
+6 | | }
+  | |_^

--- a/crates/macro/tests/ui/unsupported_item.rs
+++ b/crates/macro/tests/ui/unsupported_item.rs
@@ -1,0 +1,6 @@
+use externref_macro::externref;
+
+#[externref]
+pub struct Test;
+
+fn main() {}

--- a/crates/macro/tests/ui/unsupported_item.stderr
+++ b/crates/macro/tests/ui/unsupported_item.stderr
@@ -1,0 +1,5 @@
+error: Unsupported item; only `extern "C" {}` modules and `extern "C" fn ...` exports are supported
+ --> tests/ui/unsupported_item.rs:4:1
+  |
+4 | pub struct Test;
+  | ^^^^^^^^^^^^^^^^

--- a/crates/macro/tests/ui/variadic_fn.rs
+++ b/crates/macro/tests/ui/variadic_fn.rs
@@ -1,0 +1,8 @@
+use externref_macro::externref;
+
+#[externref]
+pub extern "C" fn printf(format: *const c_char, ...) {
+    // Do nothing
+}
+
+fn main() {}

--- a/crates/macro/tests/ui/variadic_fn.stderr
+++ b/crates/macro/tests/ui/variadic_fn.stderr
@@ -1,0 +1,5 @@
+error: Variadic functions are not supported
+ --> tests/ui/variadic_fn.rs:4:49
+  |
+4 | pub extern "C" fn printf(format: *const c_char, ...) {
+  |                                                 ^^^

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "externref-test"
 version = "0.0.0"
 edition = "2021"
 publish = false
+description = "End-to-end test crate for `externref`"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -13,6 +14,7 @@ externref = { version = "0.1.0", path = ".." }
 [dev-dependencies]
 assert_matches = "1.5.0"
 once_cell = "1.13.0"
+predicates = { version = "2.1.1", default-features = false }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 wasmtime = "1.0.1"
@@ -22,4 +24,4 @@ externref = { version = "0.1.0", path = "..", features = ["processor", "tracing"
 [dev-dependencies.tracing-capture]
 version = "0.1.0"
 git = "https://github.com/slowli/tracing-toolbox.git"
-rev = "35f6388b534c2223e29be2c720f0348de268559e"
+rev = "502655fa03d9bcd9f7721b05baba63b550b3d599"

--- a/src/processor/state.rs
+++ b/src/processor/state.rs
@@ -572,11 +572,13 @@ fn patch_type_inner(
         *placement = ValType::Externref;
     }
 
-    #[cfg(feature = "processor-log")]
-    log::debug!(
-        target: "externref",
-        "Replacing signature {:?} -> {:?} with {:?} -> {:?}",
-        params, results, new_params, new_results
+    #[cfg(feature = "tracing")]
+    tracing::debug!(
+        ?params,
+        ?results,
+        ?new_params,
+        ?new_results,
+        "replaced function signature"
     );
     Ok((new_params, new_results))
 }


### PR DESCRIPTION
- Fix an incorrect conditional compilation attr for a tracing event in the processor module.
- Test tracing output with `tracing-capture`
- Test proc macro output with `trybuild` 