### PR TITLE
Introduce guards and no-inlining for import wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
-- Fix an incorrect conditional compilation attr for a tracing event
+- Fix an incorrect conditional compilation attribute for a tracing event
   in the processor module.
+- Fix / document miscompilation resulting from optimization tools inlining
+  an `externref`-operation function. The processor now returns an error
+  if it encounters such an inlined function, and the docs mention how to avoid
+  inlining (do not run WASM optimization tools before the `externref` processor).
 
 ## 0.1.0 - 2022-10-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ walrus = { version = "0.19.0", optional = true }
 tracing = { version = "0.1.37", optional = true }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 doc-comment = "0.3.3"
 version-sync = "0.9.4"
 wat = "1.0.46"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ externref = "0.1.0"
 3. Transform the generated WASM module with the module processor
   from the corresponding module of the crate.
 
+> **Important.** The processor should run before WASM optimization tools such as
+> `wasm-opt` from binaryen.
+
 ### Examples
 
 Using the `#[externref]` macro and `Resource`s in WASM-targeting code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,27 @@ pub use externref_macro::externref;
 #[repr(transparent)]
 pub struct ExternRef(usize);
 
+impl ExternRef {
+    /// Guard for imported function wrappers. The processor checks that each transformed function
+    /// has this guard as the first instruction.
+    ///
+    /// # Safety
+    ///
+    /// This guard should only be inserted by the `externref` macro.
+    #[inline(always)]
+    pub unsafe fn guard() {
+        #[cfg(target_arch = "wasm32")]
+        #[link(wasm_import_module = "externref")]
+        extern "C" {
+            #[link_name = "guard"]
+            fn guard();
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        guard();
+    }
+}
+
 /// Host resource exposed to WASM.
 ///
 /// Internally, a resource is just an index into the `externref`s table; thus, it is completely

--- a/src/processor/error.rs
+++ b/src/processor/error.rs
@@ -72,6 +72,8 @@ pub enum Error {
     IncorrectGuard {
         /// Name of the function with an incorrectly placed guard.
         function_name: Option<String>,
+        /// WASM bytecode offset of the offending guard.
+        code_offset: Option<u32>,
     },
     /// Unexpected call to a function returning `externref`. Such calls should be confined
     /// in order for the processor to work properly. Like with [`Self::IncorrectGuard`],
@@ -79,6 +81,8 @@ pub enum Error {
     UnexpectedCall {
         /// Name of the function containing an unexpected call.
         function_name: Option<String>,
+        /// WASM bytecode offset of the offending call.
+        code_offset: Option<u32>,
     },
 }
 
@@ -139,23 +143,36 @@ impl fmt::Display for Error {
                 )
             }
 
-            Self::IncorrectGuard { function_name } => {
+            Self::IncorrectGuard {
+                function_name,
+                code_offset,
+            } => {
                 let function_name = function_name
                     .as_ref()
                     .map_or("(unnamed function)", String::as_str);
+                let code_offset = code_offset
+                    .as_ref()
+                    .map_or_else(String::new, |offset| format!(" at {offset}"));
                 write!(
                     formatter,
-                    "incorrectly placed externref guard in {function_name}. {EXTERNAL_TOOL_TIP}"
+                    "incorrectly placed externref guard in {function_name}{code_offset}. \
+                     {EXTERNAL_TOOL_TIP}"
                 )
             }
-            Self::UnexpectedCall { function_name } => {
+            Self::UnexpectedCall {
+                function_name,
+                code_offset,
+            } => {
                 let function_name = function_name
                     .as_ref()
                     .map_or("(unnamed function)", String::as_str);
+                let code_offset = code_offset
+                    .as_ref()
+                    .map_or_else(String::new, |offset| format!(" at {offset}"));
                 write!(
                     formatter,
-                    "unexpected call to an `externref`-returning function in {function_name}. \
-                     {EXTERNAL_TOOL_TIP}"
+                    "unexpected call to an `externref`-returning function \
+                     in {function_name}{code_offset}. {EXTERNAL_TOOL_TIP}"
                 )
             }
         }

--- a/src/processor/functions.rs
+++ b/src/processor/functions.rs
@@ -457,7 +457,7 @@ mod tests {
 
                 (func (param $ref i32)
                     (call $guard)
-                    (drop $ref)
+                    (drop (local.get $ref))
                 )
             )
         "#;
@@ -478,7 +478,7 @@ mod tests {
                 (import "externref" "guard" (func $guard))
 
                 (func $test (param $ref i32)
-                    (drop $ref)
+                    (drop (local.get $ref))
                     (call $guard)
                 )
             )

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -18,12 +18,18 @@
 //!
 //! See [crate-level docs](..) for more insights on WASM module setup and processing.
 //!
-//! ⚠ **Warning.** The module should run *before* WASM optimization tools such as `wasm-opt`.
+//! # On processing order
+//!
+//! ⚠ **Important.** The module should run *before* WASM optimization tools such as `wasm-opt`.
 //! These tools may inline `externref`-operating functions, which can lead to the processor
-//! producing invalid WASM code (roughly speaking, excessively replacing `i32`s with `externref`s).
-//! Running WASM optimization after the processor has an additional advantage in that it can
-//! optimize the changes produced by it; these may not be optimal on (optimization is hard, and is
-//! best left to the dedicated tools).
+//! producing invalid WASM bytecode (roughly speaking, excessively replacing `i32`s
+//! with `externref`s). Such inlining can usually be detected by the processor, in which case
+//! it will return [`Error::IncorrectGuard`] or [`Error::UnexpectedCall`]
+//! from [`process()`](Processor::process()).
+//!
+//! Optimizing WASM after the processor has an additional advantage in that it can
+//! optimize the changes produced by it (optimization is hard, and is best left
+//! to the dedicated tools).
 //!
 //! # Examples
 //!

--- a/src/processor/state.rs
+++ b/src/processor/state.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use super::{
-    functions::{ExternrefImports, PatchedFunctions},
+    functions::{get_offset, ExternrefImports, PatchedFunctions},
     Error, Location, Processor,
 };
 use crate::{Function, FunctionKind};
@@ -248,6 +248,7 @@ impl ProcessingState {
         } else if !can_have_locals {
             return Err(Error::UnexpectedCall {
                 function_name: function.name.clone(),
+                code_offset: function_offset(local_fn),
             });
         }
 
@@ -265,6 +266,14 @@ impl ProcessingState {
         ir::dfs_pre_order_mut(&mut replacer, local_fn, local_fn.entry_block());
         Ok(())
     }
+}
+
+fn function_offset(local_fn: &LocalFunction) -> Option<u32> {
+    local_fn
+        .block(local_fn.entry_block())
+        .iter()
+        .next()
+        .and_then(|(_, location)| get_offset(*location))
 }
 
 /// Visitor to detect calls to functions returning `externref`s and create a new ref local

--- a/tests/modules/simple-no-inline.wast
+++ b/tests/modules/simple-no-inline.wast
@@ -20,6 +20,7 @@
   (import "externref" "insert" (func $insert_ref (param i32) (result i32)))
   (import "externref" "get" (func $get_ref (param i32) (result i32)))
   (import "externref" "drop" (func $drop_ref (param i32)))
+  (import "externref" "guard" (func $ref_guard))
   ;; real imported fn
   (import "arena" "alloc" (func $alloc (param i32 i32) (result i32)))
 
@@ -50,6 +51,7 @@
   ;; internal fn; the `ref` local should be transformed as well
   (func (param $index i32)
     (local $ref i32)
+    (call $ref_guard)
     (local.set $ref
       (call $get_ref (local.get $index))
     )


### PR DESCRIPTION
Fixes another miscompilation resulting from inlining import wrappers. Now, the wrappers have `#[inline(never)]` on them, and there is a guard import function to detect inlining.