### PR TITLE
Fixes and casts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache cargo build
         uses: actions/cache@v3
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache cargo build
         uses: actions/cache@v3
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache cargo build
         uses: actions/cache@v3
@@ -137,9 +137,8 @@ jobs:
             && cargo rustdoc -p externref-macro -- --cfg docsrs
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: target/doc
-          SINGLE_COMMIT: true
+          branch: gh-pages
+          folder: target/doc
+          single-commit: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- Support upcasting and downcasting of `Resource`s.
+- Support expressions in `link_name` / `export_name` attributes, such as 
+  `#[export_name = concat("prefix_", stringify!($name))]` for use in macros (`$name`
+  is a macro variable). Previously, only string literals were supported.
+- Support re-exporting the crate by adding an optional `crate` parameter
+  to the `#[externref]` attribute, e.g. `#[externref(crate = "other_crate::_externref")]`
+  where `other_crate` defines `pub use externref as _externref`.
+
 ### Fixed
 
 - Fix an incorrect conditional compilation attribute for a tracing event

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -19,12 +19,37 @@
 
 extern crate proc_macro;
 
+use darling::FromMeta;
 use proc_macro::TokenStream;
-use syn::{parse::Error as SynError, Item};
+use syn::{
+    parse::{Error as SynError, Parser},
+    punctuated::Punctuated,
+    Item, NestedMeta, Path, Token,
+};
 
 mod externref;
 
 use crate::externref::{for_export, for_foreign_module};
+
+#[derive(Debug, Default, FromMeta)]
+struct ExternrefAttrs {
+    #[darling(rename = "crate", default)]
+    crate_path: Option<Path>,
+}
+
+impl ExternrefAttrs {
+    fn crate_path(&self) -> Path {
+        self.crate_path
+            .clone()
+            .unwrap_or_else(|| syn::parse_quote!(externref))
+    }
+}
+
+fn parse_attr<T: FromMeta>(tokens: TokenStream) -> syn::Result<T> {
+    let meta = Punctuated::<NestedMeta, Token![,]>::parse_terminated.parse(tokens)?;
+    let meta: Vec<_> = meta.into_iter().collect();
+    T::from_list(&meta).map_err(Into::into)
+}
 
 /// Prepares imported functions or an exported function with `Resource` args and/or return type.
 ///
@@ -41,13 +66,18 @@ use crate::externref::{for_export, for_foreign_module};
 /// - `Resource<_>`, `&Resource<_>`, `&mut Resource<_>`
 /// - `Option<_>` of any of the above three variations
 #[proc_macro_attribute]
-pub fn externref(_attr: TokenStream, input: TokenStream) -> TokenStream {
+pub fn externref(attr: TokenStream, input: TokenStream) -> TokenStream {
     const MSG: &str = "Unsupported item; only `extern \"C\" {}` modules and `extern \"C\" fn ...` \
         exports are supported";
 
+    let attrs = match parse_attr::<ExternrefAttrs>(attr) {
+        Ok(attrs) => attrs,
+        Err(err) => return err.into_compile_error().into(),
+    };
+
     let output = match syn::parse::<Item>(input) {
-        Ok(Item::ForeignMod(mut module)) => for_foreign_module(&mut module),
-        Ok(Item::Fn(mut function)) => for_export(&mut function),
+        Ok(Item::ForeignMod(mut module)) => for_foreign_module(&mut module, &attrs),
+        Ok(Item::Fn(mut function)) => for_export(&mut function, &attrs),
         Ok(other) => {
             return SynError::new_spanned(other, MSG)
                 .into_compile_error()

--- a/crates/macro/tests/ui/fn_with_bogus_export_name.stderr
+++ b/crates/macro/tests/ui/fn_with_bogus_export_name.stderr
@@ -1,11 +1,11 @@
-error: Unexpected `export_name` attribute format; expected a name-value pair
- --> tests/ui/fn_with_bogus_export_name.rs:4:1
+error: expected `=`
+ --> tests/ui/fn_with_bogus_export_name.rs:4:14
   |
 4 | #[export_name("what")]
-  | ^^^^^^^^^^^^^^^^^^^^^^
+  |              ^
 
-error: Unexpected `export_name` value; expected a string
+error: malformed `export_name` attribute input
   --> tests/ui/fn_with_bogus_export_name.rs:10:1
    |
 10 | #[export_name = 10]
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[export_name = "name"]`

--- a/crates/macro/tests/ui/module_with_bogus_link_name.stderr
+++ b/crates/macro/tests/ui/module_with_bogus_link_name.stderr
@@ -1,11 +1,11 @@
-error: Unexpected `link_name` attribute format; expected a name-value pair
- --> tests/ui/module_with_bogus_link_name.rs:6:5
+error: expected `=`
+ --> tests/ui/module_with_bogus_link_name.rs:6:16
   |
 6 |     #[link_name("huh")]
-  |     ^^^^^^^^^^^^^^^^^^^
+  |                ^
 
-error: Unexpected `link_name` value; expected a string
+error: malformed `link_name` attribute input
   --> tests/ui/module_with_bogus_link_name.rs:13:5
    |
 13 |     #[link_name = 3]
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -66,6 +66,8 @@ pub extern "C" fn test_export(sender: Resource<Sender>) {
     inspect_refs();
 }
 
+#[export_name = concat!("test_export_", stringify!(with_casts))]
+// ^ tests manually specified name with a complex expression
 #[externref]
 pub extern "C" fn test_export_with_casts(sender: Resource<()>) {
     let sender = unsafe { sender.downcast_unchecked() };

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -67,6 +67,23 @@ pub extern "C" fn test_export(sender: Resource<Sender>) {
 }
 
 #[externref]
+pub extern "C" fn test_export_with_casts(sender: Resource<()>) {
+    let sender = unsafe { sender.downcast_unchecked() };
+    let messages = ["test", "42", "some other string"]
+        .into_iter()
+        .map(|message| {
+            inspect_refs();
+            unsafe { imports::send_message(&sender, message.as_ptr(), message.len()) }.upcast()
+        });
+    let mut messages: Vec<_> = messages.collect();
+    inspect_refs();
+    messages.swap_remove(0);
+    inspect_refs();
+    drop(messages);
+    inspect_refs();
+}
+
+#[externref]
 pub extern "C" fn test_nulls(sender: Option<&Resource<Sender>>) {
     let message = "test";
     if let Some(sender) = sender {

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -6,6 +6,11 @@ pub struct Sender(());
 
 pub struct Bytes(());
 
+// Emulate reexporting the crate.
+mod reexports {
+    pub use externref as anyref;
+}
+
 mod imports {
     use externref::Resource;
 
@@ -85,7 +90,7 @@ pub extern "C" fn test_export_with_casts(sender: Resource<()>) {
     inspect_refs();
 }
 
-#[externref]
+#[externref(crate = "crate::reexports::anyref")]
 pub extern "C" fn test_nulls(sender: Option<&Resource<Sender>>) {
     let message = "test";
     if let Some(sender) = sender {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,13 @@
 //!   in a WASM module in place of `externref`s . Reference args (including mutable references)
 //!   and the `Option<_>` wrapper are supported as well.
 //! 2. Add the `#[externref]` proc macro on the imported / exported functions.
-//! 3. Post-process the generated WASM module with the [`processor`](crate::processor).
+//! 3. Post-process the generated WASM module with the [`processor`].
+//!
+//! `Resource`s support primitive downcasting and upcasting with `Resource<()>` signalling
+//! a generic resource. Downcasting is *unchecked*; it is up to the `Resource` users to
+//! define a way to check the resource kind dynamically if necessary. One possible approach
+//! for this is defining a WASM import `fn(&Resource<()>) -> Kind`, where `Kind` is the encoded
+//! kind of the supplied resource, such as `i32`.
 //!
 //! # How it works
 //!
@@ -83,13 +89,13 @@
 //!
 //! *(Off by default)*
 //!
-//! Enables WASM module processing via the [`processor`](crate::processor) module.
+//! Enables WASM module processing via the [`processor`] module.
 //!
 //! ## `tracing`
 //!
 //! *(Off by default)*
 //!
-//! Enables tracing during [module processing](crate::processor) with the [`tracing`] facade.
+//! Enables tracing during [module processing](processor) with the [`tracing`] facade.
 //! Tracing events / spans mostly use `INFO` and `DEBUG` levels.
 //!
 //! [`tracing`]: https://docs.rs/tracing/


### PR DESCRIPTION
- Introduce downcasting / upcasting for `Resource`s
- Allow re-exporting the `#[externref]` macro
- Support expressions in `link_name` / `export_name`
- Fix false positive guard check in processor