### PR TITLE
Configure release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,8 +262,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: target
-          key: ${{ runner.os }}-cargo-document-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-document
+          key: ${{ runner.os }}-document-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-document-cargo
 
       - name: Build docs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,9 @@ jobs:
           IMAGE_TAG: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
       - name: Test image (transform)
         run: |
-          cat crates/cli/tests/test.wasm | \
-          docker run -i --rm --env RUST_LOG=externref=debug "$IMAGE_TAG" - > /dev/null
+          docker run -i --rm --env RUST_LOG=externref=debug "$IMAGE_TAG" - \
+            < crates/cli/tests/test.wasm \
+            > /dev/null
         env:
           IMAGE_TAG: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags: [ "v*" ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+    name: Release ${{ matrix.target }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Determine release type
+        id: release-type
+        run: |
+          if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo 'type=release' >> "$GITHUB_OUTPUT"
+          else
+            echo 'type=prerelease' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v3
+        with:
+          path: cli/target
+          key: ${{ runner.os }}-release-cargo-${{ hashFiles('crates/cli/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-release-cargo
+
+      - name: Build CLI app
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path=crates/cli/Cargo.toml --release --target=${{ matrix.target }} --all-features --locked
+      - name: Package archive
+        id: package
+        run: ./crates/cli/package.sh ${REF#"refs/tags/"}
+        env:
+          OS: ${{ matrix.os }}
+          TARGET: ${{ matrix.target }}
+          REF: ${{ github.ref }}
+      - name: Publish archive
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          files: ${{ steps.package.outputs.archive }}
+          prerelease: ${{ steps.release-type.outputs.type == 'prerelease' }}

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -48,8 +48,9 @@ from the [GitHub Container registry](https://github.com/slowli/externref/pkgs/co
 To run the app in a Docker container, use a command like
 
 ```shell
-cat module.wasm | \
-  docker run -i --rm ghcr.io/slowli/externref:main - > processed-module.wasm
+  docker run -i --rm ghcr.io/slowli/externref:main - \
+    < module.wasm \
+    > processed-module.wasm
 ```
 
 Here, `-` is the argument to the CLI app instructing to read the input module from the stdin.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -25,7 +25,10 @@ Tracing events are output to the stderr using [the standard subscriber][fmt-subs
 its filtering can be configured using the `RUST_LOG` env variable
 (e.g., `RUST_LOG=externref=debug`).
 
-Alternatively, you may use the app Docker image [as described below](#using-docker-image).
+Alternatively, you may use the app Docker image [as described below](#using-docker-image),
+or download a pre-built app binary for popular targets (x86_64 for Linux / macOS / Windows
+and AArch64 for macOS)
+from [GitHub Releases](https://github.com/slowli/externref/releases).
 
 ## Usage
 

--- a/crates/cli/package.sh
+++ b/crates/cli/package.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Script to create an archive with the release contents (the `externref` executable
+# and the supporting docs).
+
+set -e
+
+VERSION=$1
+if [[ "$VERSION" == '' ]]; then
+  echo "Error: release version is not specified"
+  exit 1
+fi
+echo "Packaging externref $VERSION for $TARGET..."
+
+CLI_DIR=$(dirname "$0")
+RELEASE_DIR="$CLI_DIR/release"
+EXECUTABLE="$CLI_DIR/target/$TARGET/release/externref"
+
+if [[ "$OS" == 'windows-latest' ]]; then
+  EXECUTABLE="$EXECUTABLE.exe"
+fi
+if [[ ! -x $EXECUTABLE ]]; then
+  echo "Error: executable $EXECUTABLE does not exist"
+  exit 1
+fi
+
+rm -rf "$RELEASE_DIR" && mkdir "$RELEASE_DIR"
+echo "Copying release files to $RELEASE_DIR..."
+cp "$EXECUTABLE" \
+  "$CLI_DIR/README.md" \
+  "$CLI_DIR/CHANGELOG.md" \
+  "$CLI_DIR/LICENSE-APACHE" \
+  "$CLI_DIR/LICENSE-MIT" \
+  "$RELEASE_DIR"
+
+cd "$RELEASE_DIR"
+echo "Creating release archive..."
+case $OS in
+  ubuntu-latest | macos-latest)
+    ARCHIVE="externref-$VERSION-$TARGET.tar.gz"
+    tar czf "$ARCHIVE" ./*
+    ;;
+  windows-latest)
+    ARCHIVE="externref-$VERSION-$TARGET.zip"
+    7z a "$ARCHIVE" ./*
+    ;;
+  *)
+    echo "Unknown target: $TARGET"
+    exit 1
+esac
+ls -l "$ARCHIVE"
+
+if [[ "$GITHUB_OUTPUT" != '' ]]; then
+  echo "Outputting path to archive as GitHub step output: $RELEASE_DIR/$ARCHIVE"
+  echo "archive=$RELEASE_DIR/$ARCHIVE" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
Adds a GitHub workflow that attaches pre-built CLI app for 4 common targets (`x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`).