### PR TITLE
Switch off default `externref` features in CLI

### DIFF
--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -233,7 +233,6 @@ name = "externref"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "externref-macro",
  "tracing",
  "walrus",
 ]
@@ -247,15 +246,6 @@ dependencies = [
  "externref",
  "term-transcript",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "externref-macro"
-version = "0.2.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "clap",
  "externref",
  "term-transcript",
+ "test-casing",
  "tracing-subscriber",
 ]
 
@@ -820,6 +821,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "test-casing"
+version = "0.1.0"
+source = "git+https://github.com/slowli/test-casing?rev=941fe0818d047824693142fe39dc8b2ec5fd4b59#941fe0818d047824693142fe39dc8b2ec5fd4b59"
+dependencies = [
+ "test-casing-macro",
+]
+
+[[package]]
+name = "test-casing-macro"
+version = "0.1.0"
+source = "git+https://github.com/slowli/test-casing?rev=941fe0818d047824693142fe39dc8b2ec5fd4b59#941fe0818d047824693142fe39dc8b2ec5fd4b59"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"], optional =
 [dependencies.externref]
 version = "0.2.0"
 path = "../lib"
+default-features = false
 features = ["processor"]
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,11 @@ features = ["processor"]
 [dev-dependencies]
 term-transcript = { version = "0.3.0-beta.2", features = ["portable-pty"] }
 
+[dev-dependencies.test-casing]
+version = "0.1.0"
+git = "https://github.com/slowli/test-casing"
+rev = "941fe0818d047824693142fe39dc8b2ec5fd4b59"
+
 [features]
 default = ["tracing"]
 # Enables tracing output during program execution.

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -7,6 +7,8 @@ use term_transcript::{
     test::TestConfig,
     ExitStatus, PtyCommand, ShellOptions,
 };
+#[cfg(feature = "tracing")]
+use test_casing::{decorate, decorators::Retry};
 
 fn template() -> Template {
     Template::new(TemplateOptions {
@@ -28,6 +30,7 @@ fn test_config() -> TestConfig<PtyCommand> {
 
 #[cfg(feature = "tracing")]
 #[test]
+#[decorate(Retry::times(3))] // sometimes, the captured output includes `>` from the input
 fn cli_with_tracing() {
     // The WASM module is taken from the end-to-end test. We check it into the version control
     // in order for this test to be autonomous.

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -21,6 +21,11 @@ tracing-capture = "0.1.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 wasmtime = "9.0.2"
 
+[dev-dependencies.test-casing]
+version = "0.1.0"
+git = "https://github.com/slowli/test-casing"
+rev = "941fe0818d047824693142fe39dc8b2ec5fd4b59"
+
 [dev-dependencies.externref]
 path = "../crates/lib"
 features = ["processor", "tracing"]


### PR DESCRIPTION
...so that the CLI app doesn't require `externref-macro`.