### PR TITLE
Repo chores (incl. community health files)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-# Do not send the `target` dirs to the Docker builder
+# Do not send the `target` dir to the Docker builder
 target
-crates/cli/target

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Use this template for reporting issues
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Bug report
+
+<!-- Provide a concise description of the bug. -->
+
+### Steps to reproduce
+
+<!-- Describe steps to reproduce the bug. -->
+
+### Expected behavior
+
+<!-- Describe what you expected to happen from the library. -->
+
+### Environment
+
+<!-- Include relevant environment information. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Use this template to request features
+title: ''
+labels: feat
+assignees: ''
+---
+
+## Feature request
+
+<!-- Provide a concise description of the feature you'd like to see implemented. -->
+
+### Why?
+
+<!-- Explain why this feature is important, guiding use case(s) etc. -->
+
+### Alternatives
+
+<!-- Briefly describe potential alternatives you've considered. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What?
+
+<!-- Briefly describe changes in the PR. If there are several things, organize them as a list. -->
+<!-- Example: This PR adds a PR template to the repo. -->
+<!-- If applicable, attach related issue(s) -->
+
+## Why?
+
+<!-- What is the motivation behind the PR? -->
+<!-- If applicable (e.g., for PRs implementing a large new feature), describe potential alternatives
+and their pros / cons. -->
+<!-- Example: PR templates simplify contributions to the project and structure it commit log. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
     needs:
       - build
       - build-msrv
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to `externref`
+
+This project welcomes contribution from everyone, which can take form of suggestions / feature requests, bug reports, or pull requests.
+This document provides guidance how best to contribute.
+
+## Bug reports and feature requests
+
+For bugs or when asking for help, please use the bug issue template and include enough details so that your observations
+can be reproduced.
+
+For feature requests, please use the feature request issue template and describe the intended use case(s) and motivation
+to go for them. If possible, include your ideas how to implement the feature, potential alternatives and disadvantages.
+
+## Pull requests
+
+Please use the pull request template when submitting a PR. List the major goal(s) achieved by the PR
+and describe the motivation behind it. If applicable, like to the related issue(s).
+
+Optimally, you should check locally that the CI checks pass before submitting the PR. Checks included in the CI
+include:
+
+- Formatting using `cargo fmt --all`
+- Linting using `cargo clippy`
+- Linting the dependency graph using [`cargo deny`](https://crates.io/crates/cargo-deny)
+- Running the test suite using `cargo test`
+
+A complete list of checks can be viewed in [the CI workflow file](.github/workflows/ci.yml). The checks are run
+on the latest stable Rust version.
+
+### MSRV checks
+
+A part of the CI assertions is the minimum supported Rust version (MSRV). If this check fails, consult the error messages. Depending on
+the error (e.g., whether it is caused by a newer language feature used in the PR code, or in a dependency),
+you might want to rework the PR, get rid of the offending dependency, or bump the MSRV; don't hesitate to consult the maintainers.
+
+## Code of Conduct
+
+Be polite and respectful.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ The project consists of the following crates:
 Experimental; it may be the case that the processor produces invalid WASM
 in some corner cases (please report this as an issue if it does).
 
+## Contributing
+
+All contributions are welcome! See [the contributing guide](CONTRIBUTING.md) to help
+you get involved.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE)

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "externref-cli"
-version = "0.2.0"
-authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 readme = "README.md"
-license = "MIT OR Apache-2.0"
 keywords = ["externref", "anyref", "wasm"]
 categories = ["command-line-utilities", "wasm", "development-tools::ffi"]
 description = "CLI for `externref` providing WASM module processing"
-repository = "https://github.com/slowli/externref"
 
 [[bin]]
 name = "externref"


### PR DESCRIPTION
## What?

- Adds community health files (PR and issue templates, contributing guidelines).
- Removes artifacts after merging Rust workspaces left after #38.

## Why?

PR and issue templates and contributing guidelines simplify contributions to the project.