### PR TITLE
No-std support

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -44,7 +44,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo
 
       - name: Format
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check --config imports_granularity=Crate --config group_imports=StdExternalCrate
 
       - name: Clippy
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- Support `no_std` compilation mode for the library.
+
 ## 0.2.0 - 2023-06-03
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ and describe the motivation behind it. If applicable, like to the related issue(
 Optimally, you should check locally that the CI checks pass before submitting the PR. Checks included in the CI
 include:
 
-- Formatting using `cargo fmt --all`
+- Formatting using `cargo fmt --all -- --config imports_granularity=Crate --config group_imports=StdExternalCrate`
 - Linting using `cargo clippy`
 - Linting the dependency graph using [`cargo deny`](https://crates.io/crates/cargo-deny)
 - Running the test suite using `cargo test`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264b043b8e977326c1ee9e723da2c1f8d09a99df52cacf00b4dbce5ac54414d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +555,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "dlmalloc",
  "externref",
  "once_cell",
  "predicates 3.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/slowli/externref"
 # General-purpose dependencies
 anyhow = "1.0.86"
 clap = { version = "4.5.16", features = ["derive", "wrap_help"] }
+dlmalloc = "0.2.6"
 once_cell = "1.19.0"
 predicates = { version = "3.1.2", default-features = false }
 proc-macro2 = "1.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,9 +5,6 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::must_use_candidate, clippy::module_name_repetitions)]
 
-use anyhow::{anyhow, ensure, Context};
-use clap::Parser;
-
 use std::{
     fs,
     io::{self, Read as _, Write as _},
@@ -15,6 +12,8 @@ use std::{
     str::FromStr,
 };
 
+use anyhow::{anyhow, ensure, Context};
+use clap::Parser;
 use externref::processor::Processor;
 
 #[derive(Debug, Clone)]

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -34,7 +34,9 @@ version-sync.workspace = true
 wat.workspace = true
 
 [features]
-default = ["macro"]
+default = ["macro", "std"]
+# Enables `std`-specific features, like `Error` implementations
+std = []
 # Re-exports the `externref` macro
 macro = ["externref-macro"]
 # Enables WASM module processing logic (the `processor` module)

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 readme = "README.md"
 keywords = ["externref", "anyref", "wasm"]
-categories = ["wasm", "development-tools::ffi"]
+categories = ["wasm", "development-tools::ffi", "no-std"]
 description = "Low-cost reference type shims for WASM modules"
 
 [package.metadata.docs.rs]

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -34,7 +34,7 @@ version-sync.workspace = true
 wat.workspace = true
 
 [features]
-default = ["macro", "std"]
+default = ["macro"]
 # Enables `std`-specific features, like `Error` implementations
 std = []
 # Re-exports the `externref` macro

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -40,7 +40,7 @@ std = []
 # Re-exports the `externref` macro
 macro = ["externref-macro"]
 # Enables WASM module processing logic (the `processor` module)
-processor = ["anyhow", "walrus"]
+processor = ["std", "anyhow", "walrus"]
 
 [[test]]
 name = "processor"

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/slowli/externref/workflows/CI/badge.svg?branch=main)](https://github.com/slowli/externref/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%2FApache--2.0-blue)](https://github.com/slowli/externref#license)
 ![rust 1.66+ required](https://img.shields.io/badge/rust-1.66+-blue.svg?label=Required%20Rust)
+![no_std supported](https://img.shields.io/badge/no__std-tested-green.svg)
 
 **Documentation:** [![Docs.rs](https://docs.rs/externref/badge.svg)](https://docs.rs/externref/)
 [![crate docs (main)](https://img.shields.io/badge/main-yellow.svg?label=docs)](https://slowli.github.io/externref/externref/)

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -1,6 +1,8 @@
 //! Errors produced by crate logic.
 
-use std::{error, fmt, str::Utf8Error};
+use core::{fmt, str::Utf8Error};
+
+use crate::alloc::String;
 
 /// Kind of a [`ReadError`].
 #[derive(Debug)]
@@ -46,8 +48,9 @@ impl fmt::Display for ReadError {
     }
 }
 
-impl error::Error for ReadError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+#[cfg(feature = "std")]
+impl std::error::Error for ReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self.kind {
             ReadErrorKind::Utf8(err) => Some(err),
             ReadErrorKind::UnexpectedEof => None,

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -144,6 +144,7 @@
 //! }
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings.
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_root_url = "https://docs.rs/externref/0.2.0")]
@@ -158,12 +159,6 @@
 
 use core::{alloc::Layout, marker::PhantomData, mem};
 
-mod error;
-#[cfg(feature = "processor")]
-#[cfg_attr(docsrs, doc(cfg(feature = "processor")))]
-pub mod processor;
-mod signature;
-
 pub use crate::{
     error::{ReadError, ReadErrorKind},
     signature::{BitSlice, BitSliceBuilder, Function, FunctionKind},
@@ -171,6 +166,20 @@ pub use crate::{
 #[cfg(feature = "macro")]
 #[cfg_attr(docsrs, doc(cfg(feature = "macro")))]
 pub use externref_macro::externref;
+
+mod error;
+#[cfg(feature = "processor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "processor")))]
+pub mod processor;
+mod signature;
+
+// Polyfill for `alloc` types.
+mod alloc {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc as std;
+
+    pub(crate) use std::{format, string::String};
+}
 
 /// `externref` surrogate.
 ///

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -159,13 +159,14 @@
 
 use core::{alloc::Layout, marker::PhantomData, mem};
 
+#[cfg(feature = "macro")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macro")))]
+pub use externref_macro::externref;
+
 pub use crate::{
     error::{ReadError, ReadErrorKind},
     signature::{BitSlice, BitSliceBuilder, Function, FunctionKind},
 };
-#[cfg(feature = "macro")]
-#[cfg_attr(docsrs, doc(cfg(feature = "macro")))]
-pub use externref_macro::externref;
 
 mod error;
 #[cfg(feature = "processor")]

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -85,6 +85,12 @@
 //!
 //! # Crate features
 //!
+//! ## `std`
+//!
+//! *(On by default)*
+//!
+//! Enables `std`-specific features, like [`Error`](std::error::Error) implementations for error types.
+//!
 //! ## `processor`
 //!
 //! *(Off by default)*

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -87,7 +87,7 @@
 //!
 //! ## `std`
 //!
-//! *(On by default)*
+//! *(Off by default)*
 //!
 //! Enables `std`-specific features, like [`Error`](std::error::Error) implementations for error types.
 //!
@@ -95,7 +95,7 @@
 //!
 //! *(Off by default)*
 //!
-//! Enables WASM module processing via the [`processor`] module.
+//! Enables WASM module processing via the [`processor`] module. Requires the `std` feature.
 //!
 //! ## `tracing`
 //!

--- a/crates/lib/src/processor/functions.rs
+++ b/crates/lib/src/processor/functions.rs
@@ -1,13 +1,15 @@
 //! Patched functions for working with `externref`s.
 
+use std::{
+    cmp,
+    collections::{HashMap, HashSet},
+};
+
 use walrus::{
     ir::{self, BinaryOp},
     Function, FunctionBuilder, FunctionId, FunctionKind as WasmFunctionKind, ImportKind,
     InstrLocId, InstrSeqBuilder, LocalFunction, LocalId, Module, ModuleImports, TableId, ValType,
 };
-
-use std::collections::HashSet;
-use std::{cmp, collections::HashMap};
 
 use super::{Error, Processor};
 

--- a/crates/lib/src/processor/mod.rs
+++ b/crates/lib/src/processor/mod.rs
@@ -48,13 +48,13 @@
 
 use walrus::{passes::gc, Module};
 
-mod error;
-mod functions;
-mod state;
-
 pub use self::error::{Error, Location};
 use self::state::ProcessingState;
 use crate::Function;
+
+mod error;
+mod functions;
+mod state;
 
 /// WASM module processor encapsulating processing options.
 #[derive(Debug)]

--- a/crates/lib/src/processor/state.rs
+++ b/crates/lib/src/processor/state.rs
@@ -1,13 +1,13 @@
 //! Stateful WASM module processing.
 
-use walrus::{
-    ir, ExportItem, FunctionBuilder, FunctionId, ImportKind, LocalFunction, LocalId, Module,
-    ModuleLocals, ModuleTypes, TypeId, ValType,
-};
-
 use std::{
     collections::{HashMap, HashSet},
     iter, mem,
+};
+
+use walrus::{
+    ir, ExportItem, FunctionBuilder, FunctionId, ImportKind, LocalFunction, LocalId, Module,
+    ModuleLocals, ModuleTypes, TypeId, ValType,
 };
 
 use super::{

--- a/crates/lib/src/signature.rs
+++ b/crates/lib/src/signature.rs
@@ -1,8 +1,11 @@
 //! Function signatures recorded into a custom section of WASM modules.
 
-use std::str;
+use core::str;
 
-use crate::error::{ReadError, ReadErrorKind};
+use crate::{
+    alloc::{format, String},
+    error::{ReadError, ReadErrorKind},
+};
 
 /// Builder for [`BitSlice`]s that can be used in const contexts.
 #[doc(hidden)] // used by macro; not public (yet?)

--- a/crates/lib/tests/processor.rs
+++ b/crates/lib/tests/processor.rs
@@ -1,10 +1,9 @@
 //! Tests for processor logic.
 
-use walrus::{ExportItem, ImportKind, Module, RawCustomSection, ValType};
-
 use std::path::Path;
 
 use externref::{processor::Processor, BitSlice, Function, FunctionKind};
+use walrus::{ExportItem, ImportKind, Module, RawCustomSection, ValType};
 
 const ARENA_ALLOC: Function<'static> = Function {
     kind: FunctionKind::Import("arena"),

--- a/crates/macro/src/externref.rs
+++ b/crates/macro/src/externref.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, mem};
+
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{
@@ -5,8 +7,6 @@ use syn::{
     FnArg, ForeignItem, GenericArgument, Ident, ItemFn, ItemForeignMod, Lit, LitStr, Meta, PatType,
     Path, PathArguments, Signature, Token, Type, TypePath, Visibility,
 };
-
-use std::{collections::HashMap, mem};
 
 use crate::ExternrefAttrs;
 

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -10,7 +10,10 @@ description = "End-to-end test crate for `externref`"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-externref = { workspace = true, default-features = true }
+externref = { workspace = true, features = ["default"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+dlmalloc = { workspace = true, features = ["global"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -1,12 +1,22 @@
 //! E2E test for `externref`.
 
-#![no_std]
+#![cfg_attr(target_arch = "wasm32", no_std)]
 
 extern crate alloc;
 
 use alloc::vec::Vec;
 
 use externref::{externref, Resource};
+
+#[cfg(target_arch = "wasm32")]
+#[global_allocator]
+static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+#[cfg(target_arch = "wasm32")]
+#[panic_handler]
+fn handle_panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
 
 pub struct Sender(());
 

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -1,5 +1,11 @@
 //! E2E test for `externref`.
 
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 use externref::{externref, Resource};
 
 pub struct Sender(());

--- a/e2e-tests/tests/integration/main.rs
+++ b/e2e-tests/tests/integration/main.rs
@@ -1,7 +1,10 @@
 //! End-to-end tests for the `externref` macro / processor.
 
+use std::{collections::HashSet, sync::Once};
+
 use anyhow::{anyhow, Context};
 use assert_matches::assert_matches;
+use externref::processor::Processor;
 use once_cell::sync::Lazy;
 use test_casing::{test_casing, Product};
 use tracing::{subscriber::DefaultGuard, Level, Subscriber};
@@ -11,13 +14,9 @@ use tracing_subscriber::{
 };
 use wasmtime::{Caller, Engine, Extern, ExternRef, Linker, Module, Store, Table, Val};
 
-use std::{collections::HashSet, sync::Once};
-
-use externref::processor::Processor;
+use crate::compile::compile;
 
 mod compile;
-
-use crate::compile::compile;
 
 type RefAssertion = fn(Caller<'_, Data>, &Table);
 


### PR DESCRIPTION
## What?

Enables no-std support in the main crate. Tests it by making the test WASM module `no_std`.

## Why?

WASM applications often try to minimize file size, and a common way of doing this is to make the crate `#![no_std]` to remove unnecessary code from the standard library (such as the built in panic handler, in some cases).

closes #154 