### PR TITLE
fix: Fix error cause when compiling with `dev` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ lto = true
 
 # Required to properly inline surrogate `externref`s (see "Limitations" in the crate docs)
 [profile.dev.package.externref-test]
-opt-level = 2
+debug = 1

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -61,11 +61,11 @@ that can process WASM modules with slightly less fine-grained control.
 ### Limitations
 
 If you compile WASM without compilation optimizations, you might get "incorrectly placed externref guard" errors during WASM processing.
-Currently, the only workaround is to enable at least some optimizations for the compiled WASM module, e.g. using a workspace manifest:
+Currently, the only workaround is to switch off some debug info for the compiled WASM module, e.g. using a workspace manifest:
 
 ```toml,no_sync
 [profile.dev.package.your-wasm-module]
-opt-level = 2
+debug = 1 # or "limited" if you're targeting MSRV 1.71+
 ```
 
 These errors shouldn't occur if WASM is compiled in the release mode.

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -85,12 +85,13 @@
 //!
 //! ## Limitations
 //!
-//! Without compilation optimizations enabled, surrogate `usize`s may be spilled onto the shadow stack (part
+//! With debug info enabled, surrogate `usize`s may be spilled onto the shadow stack (part
 //! of the WASM linear memory used by `rustc` / LLVM when the main WASM stack is insufficient).
 //! This makes replacing these surrogates with `externref`s much harder (essentially, it'd require symbolic execution
 //! of the affected function to find out which locals should be replaced with `externref`s). This behavior should be detected
 //! by the [processor](processor), leading to "incorrectly placed externref guard" errors. Currently,
-//! the only workaround is to enable optimizations for the compiled WASM module.
+//! the only workaround is to [set debug info level](https://doc.rust-lang.org/cargo/reference/profiles.html#debug)
+//! to `limited` or below for the compiled WASM module.
 //!
 //! # Crate features
 //!


### PR DESCRIPTION
## What?

Attributes the error cause when compiling `externref` code with the `dev` profile to debug information, and changes the suggested workaround correspondingly.

## Why?

The previously mentioned workaround doesn't always work.

fixes #171