### PR TITLE
support actual paths

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -44,18 +44,11 @@ impl ExternrefAttrs {
         let parser = syn::meta::parser(|meta| {
             if meta.path.is_ident("crate") {
                 let value = meta.value()?;
-                let value: proc_macro2::TokenStream = value.parse()?;
-                // let value = meta.input;
-                match parse2(value.clone()) {
-                    Err(_) => {
-                        let path_str: syn::LitStr = parse2(value)?;
-                        attrs.crate_path = Some(path_str.parse()?);
-                    }
-                    Ok(mut path) => {
-                        // path = value.parse()?;
-                        attrs.crate_path = Some(path)
-                    }
-                }
+                attrs.crate_path = Some(if let Ok(path_str) = value.parse::<syn::LitStr>() {
+                    path_str.parse()?
+                } else {
+                    value.parse()?
+                });
                 Ok(())
             } else {
                 Err(meta.error("unsupported attribute"))

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -21,7 +21,8 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use syn::{
-    parse::{Error as SynError, Parser}, parse2, Item, Path
+    parse::{Error as SynError, Parser},
+    parse2, Item, Path,
 };
 
 mod externref;
@@ -53,7 +54,7 @@ impl ExternrefAttrs {
                     Ok(mut path) => {
                         // path = value.parse()?;
                         attrs.crate_path = Some(path)
-                    },
+                    }
                 }
                 Ok(())
             } else {

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -22,7 +22,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::{
     parse::{Error as SynError, Parser},
-    parse2, Item, Path,
+    Item, Path,
 };
 
 mod externref;

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -115,3 +115,13 @@ pub extern "C" fn test_nulls(sender: Option<&Resource<Sender>>) {
     }
     assert_eq!(unsafe { imports::message_len(None) }, 0);
 }
+
+#[externref(crate = crate::reexports::anyref)]
+pub extern "C" fn test_nulls2(sender: Option<&Resource<Sender>>) {
+    let message = "test";
+    if let Some(sender) = sender {
+        let bytes = unsafe { imports::send_message(sender, message.as_ptr(), message.len()) };
+        assert_eq!(unsafe { imports::message_len(Some(&bytes)) }, 4);
+    }
+    assert_eq!(unsafe { imports::message_len(None) }, 0);
+}

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -118,10 +118,5 @@ pub extern "C" fn test_nulls(sender: Option<&Resource<Sender>>) {
 
 #[externref(crate = crate::reexports::anyref)]
 pub extern "C" fn test_nulls2(sender: Option<&Resource<Sender>>) {
-    let message = "test";
-    if let Some(sender) = sender {
-        let bytes = unsafe { imports::send_message(sender, message.as_ptr(), message.len()) };
-        assert_eq!(unsafe { imports::message_len(Some(&bytes)) }, 4);
-    }
-    assert_eq!(unsafe { imports::message_len(None) }, 0);
+    test_nulls(sender);
 }

--- a/e2e-tests/tests/integration/main.rs
+++ b/e2e-tests/tests/integration/main.rs
@@ -245,7 +245,7 @@ fn assert_tracing_output(storage: &Storage) {
     let spans = storage.scan_spans();
     let process_span = spans.single(&name(eq("process")));
     let matches =
-        level(Level::INFO) & message(eq("parsed custom section")) & field("functions.len", 5_u64);
+        level(Level::INFO) & message(eq("parsed custom section")) & field("functions.len", 6_u64);
     process_span.scan_events().single(&matches);
 
     let patch_imports_span = spans.single(&name(eq("patch_imports")));


### PR DESCRIPTION
## What?

This PR allows actual `syn::Path`s to be used as the crate path. It also is backward compatible with the current strings-as-paths system.

## Why?

`macro_rules` macros create special tokens which cannot be recreated from a string. To support them in paths, namely, the path to `externref`, we would need to support actual paths instead of path strings. 
