### PR TITLE
test: Fix potential export deduplication in E2E test

### DIFF
--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -116,7 +116,9 @@ pub extern "C" fn test_nulls(sender: Option<&Resource<Sender>>) {
     assert_eq!(unsafe { imports::message_len(None) }, 0);
 }
 
+// Add another param to the function so that it's not deduped with `test_nulls`
+// (incl. by `wasm-opt` over which we don't have any control).
 #[externref(crate = crate::reexports::anyref)]
-pub extern "C" fn test_nulls2(sender: Option<&Resource<Sender>>) {
+pub extern "C" fn test_nulls2(sender: Option<&Resource<Sender>>, _unused: u32) {
     test_nulls(sender);
 }

--- a/e2e-tests/tests/integration/main.rs
+++ b/e2e-tests/tests/integration/main.rs
@@ -309,7 +309,7 @@ fn assert_tracing_output(storage: &Storage) {
     );
     assert_eq!(
         transformed_exports.len(),
-        1 + contains_export as usize + contains_export_with_casts as usize,
+        2 + contains_export as usize + contains_export_with_casts as usize,
         "{transformed_exports:?}"
     );
 }


### PR DESCRIPTION
## What?

Fixes a potential export deduplication in the E2E test.

## Why?

Currently, the E2E test may fail because of the said deduplication.