### PR TITLE
fixing take_raw dropping the externref before resolving it.

### DIFF
--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -326,7 +326,7 @@ impl<T> Resource<T> {
     #[inline(always)]
     #[allow(clippy::needless_pass_by_value)]
     pub unsafe fn take_raw(this: Option<Self>) -> ExternRef {
-        get_externref(match this {
+        get_externref(match this.as_ref() {
             None => usize::MAX,
             Some(resource) => resource.id,
         })


### PR DESCRIPTION
## What?

Currently, a `#[externref]` function that returns a `Resource<..>` will always return `null`.  
The issue lies in `Resource::take_raw`: it drops the resource ID (and frees the slot) *before* `get_externref` is called.  

This means that by the time `get_externref` tries to retrieve the `ExternRef`, the underlying resource has already been dropped.  

## Fix

The fix is to delay dropping the `Resource<..>` until the end of the function.  
This ensures that `get_externref` can lookup the `ExternRef` before the slot is emptied.
