### PR TITLE
chore: Bump crate versions to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.3.0 - 2026-07-19
+
+*(All changes are relative compared to [the 0.3.0-beta.1 release](#030-beta1---2024-09-29))*
+
 ### Added
 
 - Implement `PartialEq`, `Eq` and `Hash` traits for `Resource`s based on (externref) pointer comparison.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "externref"
-version = "0.3.0-beta.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "externref-cli"
-version = "0.3.0-beta.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "externref-macro"
-version = "0.3.0-beta.1"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cli", "crates/lib", "crates/macro", "e2e-tests"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0-beta.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 authors = [
@@ -39,8 +39,8 @@ wasmtime = "46.0.1"
 wat = "1.253.0"
 
 # Internal dependencies
-externref-macro = { version = "=0.3.0-beta.1", path = "crates/macro" }
-externref = { version = "=0.3.0-beta.1", path = "crates/lib", default-features = false }
+externref-macro = { version = "=0.3.0", path = "crates/macro" }
+externref = { version = "=0.3.0", path = "crates/lib", default-features = false }
 # ^ We require an exact version in order to simplify crate evolution (e.g., to not worry
 # that future internal changes in macro implementations will break previous versions
 # of the `externref` crate).

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -43,7 +43,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-externref = "0.3.0-beta.1"
+externref = "0.3.0"
 ```
 
 1. Use `Resource`s as arguments / return results for imported and/or exported functions

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -163,7 +163,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/externref/0.3.0-beta.1")]
+#![doc(html_root_url = "https://docs.rs/externref/0.3.0")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/crates/macro/README.md
+++ b/crates/macro/README.md
@@ -19,7 +19,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-externref-macro = "0.3.0-beta.1"
+externref-macro = "0.3.0"
 ```
 
 Note that the `externref` crate re-exports the proc macro if the `macro` crate feature

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![recursion_limit = "128"]
 // Documentation settings.
-#![doc(html_root_url = "https://docs.rs/externref-macro/0.3.0-beta.1")]
+#![doc(html_root_url = "https://docs.rs/externref-macro/0.3.0")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -4,7 +4,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-externref = "0.3.0-beta.1"
+externref = "0.3.0"
 ```
 
 See [the library docs](crates/externref) for detailed description of its API.


### PR DESCRIPTION
## What?

Bumps crate versions to 0.3.0 (the next stable release).

## Why?

There are quite a few changes from 0.3.0-beta.1.
