### PR TITLE
support for ref extern types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- Support non-null WASM reference types (`(ref extern)`) on imported and exported
+  function arguments and results, including JS string builtins.
+
+### Changed
+
+- **Breaking:** Derive WASM nullability from Rust types. `Resource`, `ResourceCopy` and
+  their references now use `(ref extern)`; `Option` forms use `(ref null extern)`.
+
+### Fixed
+
+- Handle optional mutable resource references in generated import wrappers.
+- Recognize debug import guards after argument spills in the stack prologue.
+
 ## 0.3.0 - 2026-07-19
 
 *(All changes are relative compared to [the 0.3.0-beta.1 release](#030-beta1---2024-09-29))*

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -59,6 +59,49 @@ that can process WASM modules with slightly less fine-grained control.
 > **Important.** The processor should run before WASM optimization tools such as
 > `wasm-opt` from binaryen.
 
+### Reference nullability
+
+The Rust argument or return type determines nullability in the processed WASM signature:
+
+| Rust type | WASM type |
+| --- | --- |
+| `Resource<T>` | `(ref extern)` |
+| `&Resource<T>` | `(ref extern)` |
+| `&mut Resource<T>` | `(ref extern)` |
+| `Option<Resource<T>>` | `(ref null extern)` |
+| `Option<&Resource<T>>` | `(ref null extern)` |
+| `Option<&mut Resource<T>>` | `(ref null extern)` |
+
+The same rules apply to `ResourceCopy` and resource type aliases marked with `#[resource]`.
+The `Option` wrapper must be visible in the signature for the macro to recognize it.
+No separate nullability attribute is needed.
+
+For example, the JS string `cast` builtin requires a nullable parameter and a non-null result:
+
+```rust,no_run
+use externref::{externref, Resource};
+
+#[externref(stubs)]
+#[link(wasm_import_module = "wasm:js-string")]
+unsafe extern "C" {
+    fn cast(value: Option<&Resource<()>>) -> Resource<()>;
+}
+```
+
+An existing resource can be passed as `cast(Some(&resource))`. Use `Option` in an import
+signature whenever the host requires a nullable WASM type, even if the host rejects null
+values at runtime, as JS string builtins do.
+
+The Rust representation and resource cleanup are unchanged. The internal table remains
+nullable, and the processor inserts `ref.as_non_null` checks where references leave it
+through a non-null interface. Nullable resources already map host nulls to `None` at runtime;
+no additional Rust wrapper type is required.
+
+Use the matching updated processor or CLI: older processors do not read the supplementary
+non-null metadata. The WASM engine must support non-null reference types. When optimizing
+with Binaryen, enable GC support with `wasm-opt --enable-gc`; otherwise, it can lower
+non-null signatures to nullable ones and invalidate builtin imports.
+
 ### Limitations
 
 If you compile WASM without compilation optimizations, you might get "incorrectly placed externref guard" errors during WASM processing.
@@ -87,7 +130,7 @@ pub struct Bytes(());
 #[externref]
 #[link(wasm_import_module = "arena")]
 extern "C" {
-    // This import will have signature `(externref, i32) -> externref`
+    // This import will have signature `((ref extern), i32) -> externref`
     // on host.
     fn alloc(arena: &Resource<Arena>, size: usize) 
         -> Option<Resource<Bytes>>;
@@ -98,7 +141,7 @@ extern "C" {
 unsafe fn alloc(_: &Resource<Arena>, _: usize) 
     -> Option<Resource<Bytes>> { None }
 
-// This export will have signature `(externref) -> ()` on host.
+// This export will have signature `((ref extern)) -> ()` on host.
 #[externref]
 #[unsafe(export_name = "test_export")]
 pub extern "C" fn test_export(arena: &Resource<Arena>) {

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -38,6 +38,10 @@
 //! 2. Add the `#[externref]` proc macro on the imported / exported functions.
 //! 3. Post-process the generated WASM module with the [`processor`].
 //!
+//! `Resource<T>`, `&Resource<T>` and `&mut Resource<T>` use non-null `(ref extern)`
+//! in WASM signatures. Their `Option<_>` forms use nullable `externref`
+//! (`(ref null extern)`). The same rules apply to [`ResourceCopy`].
+//!
 //! `Resource`s support primitive downcasting and upcasting with `Resource<()>` signalling
 //! a generic resource. Downcasting is *unchecked*; it is up to the `Resource` users to
 //! define a way to check the resource kind dynamically if necessary. One possible approach
@@ -50,8 +54,8 @@
 //! for imported and exported functions. All `Resource` args or return types are replaced
 //! with `usize`s and a wrapper function is added that performs the necessary transform
 //! from / to `usize`.
-//! Additionally, a function signature describing where `Resource` args are located
-//! is recorded in a WASM custom section.
+//! Additionally, function signature metadata records where resources are located
+//! and which arguments or results are non-null.
 //!
 //! To handle `usize` (~`i32` in WASM) <-> `externref` conversions, managing resources is performed
 //! using 3 function imports from a surrogate module:
@@ -130,7 +134,7 @@
 //! #[externref]
 //! #[link(wasm_import_module = "test")]
 //! unsafe extern "C" {
-//!     // This import will have signature `(externref, i32, i32) -> externref`
+//!     // This import will have signature `((ref extern), i32, i32) -> (ref extern)`
 //!     // on host.
 //!     fn send_message(
 //!         sender: &Resource<Sender>,
@@ -145,7 +149,7 @@
 //!     fn last_sender() -> Option<Resource<Sender>>;
 //! }
 //!
-//! // This export will have signature `(externref)` on host.
+//! // This export will have signature `((ref extern)) -> ()` on host.
 //! #[externref]
 //! #[unsafe(export_name = "test_export")]
 //! pub extern "C" fn test_export(sender: Resource<Sender>) {

--- a/crates/lib/src/processor/error.rs
+++ b/crates/lib/src/processor/error.rs
@@ -32,6 +32,15 @@ pub enum Error {
     Read(ReadError),
     /// Error parsing the WASM module.
     Wasm(anyhow::Error),
+    /// Non-null metadata is present without the primary function declarations.
+    MissingExternrefSection,
+    /// Non-null metadata marks an argument or result that is not an `externref`.
+    InvalidNonNullSignature {
+        /// Name of the module; `None` for exported functions.
+        module: Option<String>,
+        /// Name of the function.
+        name: String,
+    },
 
     /// Unexpected type of an import (expected a function).
     UnexpectedImportType {
@@ -94,6 +103,21 @@ impl fmt::Display for Error {
         match self {
             Self::Read(err) => write!(formatter, "failed reading WASM custom section: {err}"),
             Self::Wasm(err) => write!(formatter, "failed reading WASM module: {err}"),
+            Self::MissingExternrefSection => {
+                write!(
+                    formatter,
+                    "non-null metadata requires the `__externrefs` section"
+                )
+            }
+            Self::InvalidNonNullSignature { module, name } => {
+                let module_descr = module
+                    .as_ref()
+                    .map_or_else(String::new, |module| format!(" imported from `{module}`"));
+                write!(
+                    formatter,
+                    "non-null metadata for function `{name}`{module_descr} must only mark externrefs"
+                )
+            }
 
             Self::UnexpectedImportType { module, name } => {
                 write!(

--- a/crates/lib/src/processor/functions.rs
+++ b/crates/lib/src/processor/functions.rs
@@ -374,11 +374,11 @@ impl ir::VisitorMut for GuardRemover {
     fn start_instr_seq_mut(&mut self, instr_seq: &mut ir::InstrSeq) {
         let is_entry_seq = instr_seq.id() == self.entry_seq_id;
         let mut idx = 0;
-        let mut maybe_set_stack_ptr = false;
+        let mut in_stack_prologue = false;
         instr_seq.instrs.retain(|(instr, location)| {
             let placement = if let ir::Instr::Call(call) = instr {
                 if call.func == self.guard_id {
-                    Some(if is_entry_seq && (idx == 0 || maybe_set_stack_ptr) {
+                    Some(if is_entry_seq && (idx == 0 || in_stack_prologue) {
                         GuardPlacement::Correct
                     } else {
                         GuardPlacement::Incorrect(get_offset(*location))
@@ -394,7 +394,16 @@ impl ir::VisitorMut for GuardRemover {
                 self.add_placement(placement);
             }
             idx += 1;
-            maybe_set_stack_ptr = matches!(instr, ir::Instr::GlobalSet(_));
+            in_stack_prologue = matches!(instr, ir::Instr::GlobalSet(_))
+                || (in_stack_prologue
+                    && matches!(
+                        instr,
+                        ir::Instr::LocalGet(_)
+                            | ir::Instr::LocalSet(_)
+                            | ir::Instr::LocalTee(_)
+                            | ir::Instr::Load(_)
+                            | ir::Instr::Store(_)
+                    ));
             placement.is_none()
         });
     }
@@ -510,6 +519,68 @@ mod tests {
         let fns = PatchedFunctions::new(&mut module, &imports, &Processor::default());
         let (_, guarded_fns) = fns.replace_calls(&mut module).unwrap();
         assert_eq!(guarded_fns.len(), 1);
+    }
+
+    #[test]
+    fn guarded_function_spilling_args_to_stack() {
+        const MODULE_BYTES: &[u8] = br#"
+            (module
+                (import "externref" "guard" (func $guard))
+                (global $__stack_pointer (mut i32) (i32.const 32768))
+                (memory 1)
+
+                (func (param $resource i32)
+                    (local $frame i32)
+                    (global.set $__stack_pointer
+                        (local.tee $frame
+                            (i32.sub (global.get $__stack_pointer) (i32.const 32))
+                        )
+                    )
+                    (i32.store offset=16 (local.get $frame) (local.get $resource))
+                    (i32.store offset=12
+                        (local.get $frame)
+                        (i32.load offset=16 (local.get $frame))
+                    )
+                    (call $guard)
+                    (drop (local.get $resource))
+                )
+            )
+        "#;
+
+        let bytes = wat::parse_bytes(MODULE_BYTES).unwrap();
+        let mut module = Module::from_buffer(&bytes).unwrap();
+        let imports = ExternrefImports::new(&mut module.imports).unwrap();
+        let functions = PatchedFunctions::new(&mut module, &imports, &Processor::default());
+        let (_, guarded_fns) = functions.replace_calls(&mut module).unwrap();
+        assert_eq!(guarded_fns.len(), 1);
+    }
+
+    #[test]
+    fn call_before_guard_ends_stack_prologue() {
+        const MODULE_BYTES: &[u8] = br#"
+            (module
+                (import "externref" "guard" (func $guard))
+                (import "test" "callback" (func $callback))
+                (global $__stack_pointer (mut i32) (i32.const 32768))
+
+                (func $test
+                    (global.set $__stack_pointer
+                        (i32.sub (global.get $__stack_pointer) (i32.const 16))
+                    )
+                    (call $callback)
+                    (call $guard)
+                )
+            )
+        "#;
+
+        let bytes = wat::parse_bytes(MODULE_BYTES).unwrap();
+        let mut module = Module::from_buffer(&bytes).unwrap();
+        let imports = ExternrefImports::new(&mut module.imports).unwrap();
+        let functions = PatchedFunctions::new(&mut module, &imports, &Processor::default());
+        assert_matches!(
+            functions.replace_calls(&mut module),
+            Err(Error::IncorrectGuard { function_name: Some(name), .. }) if name == "test"
+        );
     }
 
     #[test]

--- a/crates/lib/src/processor/mod.rs
+++ b/crates/lib/src/processor/mod.rs
@@ -12,6 +12,8 @@
 //!   local functions.
 //! - Patch signatures and implementations of imported / exported functions so that they
 //!   use `externref`s where appropriate.
+//! - Apply optional non-null signature declarations, using `ref.as_non_null` adapters
+//!   where nullable internal references cross a non-null interface.
 //! - Add an initially empty, unconstrained table with `externref` elements and optionally
 //!   export it from the module. The host can use the table to inspect currently used references
 //!   (e.g., to save / restore WASM instance state).
@@ -30,6 +32,8 @@
 //! Optimizing WASM after the processor has an additional advantage in that it can
 //! optimize the changes produced by it (optimization is hard, and is best left
 //! to the dedicated tools).
+//! When non-null references are used, pass `--enable-gc` to Binaryen to prevent it from
+//! lowering non-null signatures back to nullable ones.
 //!
 //! # Examples
 //!
@@ -58,6 +62,11 @@ mod state;
 
 /// Externref type as a constant.
 const EXTERNREF: ValType = ValType::Ref(RefType::EXTERNREF);
+
+const NON_NULL_EXTERNREF: ValType = ValType::Ref(RefType {
+    nullable: false,
+    ..RefType::EXTERNREF
+});
 
 /// WASM module processor encapsulating processing options.
 #[derive(Debug)]
@@ -105,18 +114,28 @@ impl<'a> Processor<'a> {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, err))]
     pub fn process(&self, module: &mut Module) -> Result<(), Error> {
         let raw_section = module.customs.remove_raw(Function::CUSTOM_SECTION_NAME);
+        let non_null_section = module
+            .customs
+            .remove_raw(Function::NON_NULL_CUSTOM_SECTION_NAME);
         let Some(raw_section) = raw_section else {
+            if non_null_section.is_some() {
+                return Err(Error::MissingExternrefSection);
+            }
             #[cfg(feature = "tracing")]
             tracing::info!("module contains no custom section; skipping");
             return Ok(());
         };
         let functions = Self::parse_section(&raw_section.data)?;
+        let non_null_functions = non_null_section
+            .as_ref()
+            .map_or_else(|| Ok(vec![]), |section| Self::parse_section(&section.data))?;
         #[cfg(feature = "tracing")]
         tracing::info!(functions.len = functions.len(), "parsed custom section");
 
         let state = ProcessingState::new(module, self)?;
         let guarded_fns = state.replace_functions(module)?;
         state.process_functions(&functions, &guarded_fns, module)?;
+        ProcessingState::process_non_null_functions(&non_null_functions, module)?;
 
         gc::run(module);
         Ok(())

--- a/crates/lib/src/processor/state.rs
+++ b/crates/lib/src/processor/state.rs
@@ -11,7 +11,7 @@ use walrus::{
 };
 
 use super::{
-    EXTERNREF, Error, Location, Processor,
+    EXTERNREF, Error, Location, NON_NULL_EXTERNREF, Processor,
     functions::{ExternrefImports, PatchedFunctions, get_offset},
 };
 use crate::{Function, FunctionKind};
@@ -89,6 +89,72 @@ impl ProcessingState {
             }
         }
 
+        Ok(())
+    }
+
+    pub fn process_non_null_functions(
+        functions: &[Function<'_>],
+        module: &mut Module,
+    ) -> Result<(), Error> {
+        for function in functions {
+            let Some(fn_id) = Self::function_id(function, module)? else {
+                continue;
+            };
+            let original_ty = module.funcs.get(fn_id).ty();
+            let (params, results) = module.types.params_results(original_ty);
+            let params = params.to_vec();
+            let results = results.to_vec();
+            if params.len() + results.len() != function.externrefs.bit_len() {
+                return Err(Error::UnexpectedArity {
+                    module: fn_module(&function.kind).map(str::to_owned),
+                    name: function.name.to_owned(),
+                    expected_arity: function.externrefs.bit_len(),
+                    real_arity: params.len() + results.len(),
+                });
+            }
+
+            let mut new_params = params.clone();
+            let mut new_results = results.clone();
+            for idx in function.externrefs.set_indices() {
+                let placement = if idx < new_params.len() {
+                    &mut new_params[idx]
+                } else {
+                    &mut new_results[idx - new_params.len()]
+                };
+                if *placement != EXTERNREF {
+                    return Err(Error::InvalidNonNullSignature {
+                        module: fn_module(&function.kind).map(str::to_owned),
+                        name: function.name.to_owned(),
+                    });
+                }
+                *placement = NON_NULL_EXTERNREF;
+            }
+
+            match function.kind {
+                FunctionKind::Import(_) => {
+                    let new_ty = module.types.add(&new_params, &new_results);
+                    if new_params == params {
+                        module.funcs.get_mut(fn_id).kind.unwrap_import_mut().ty = new_ty;
+                    } else {
+                        let import_id = module.funcs.get(fn_id).kind.unwrap_import().import;
+                        let target_id = module.funcs.add_import(new_ty, import_id);
+                        module.imports.get_mut(import_id).kind = ImportKind::Function(target_id);
+                        let adapter = non_null_adapter(module, target_id, &params, &results);
+                        module.funcs.get_mut(fn_id).kind = walrus::FunctionKind::Local(adapter);
+                    }
+                }
+                FunctionKind::Export => {
+                    let adapter = non_null_adapter(module, fn_id, &new_params, &new_results);
+                    let adapter_id = module.funcs.add_local(adapter);
+                    let export = module
+                        .exports
+                        .iter_mut()
+                        .find(|export| export.name == function.name)
+                        .unwrap();
+                    export.item = ExportItem::Function(adapter_id);
+                }
+            }
+        }
         Ok(())
     }
 
@@ -260,6 +326,51 @@ impl ProcessingState {
         ir::dfs_pre_order_mut(&mut replacer, local_fn, local_fn.entry_block());
         Ok(())
     }
+}
+
+fn non_null_adapter(
+    module: &mut Module,
+    target_id: FunctionId,
+    params: &[ValType],
+    results: &[ValType],
+) -> LocalFunction {
+    let target_ty = module.funcs.get(target_id).ty();
+    let (target_params, target_results) = module.types.params_results(target_ty);
+    let target_params = target_params.to_vec();
+    let target_results = target_results.to_vec();
+    let mut builder = FunctionBuilder::new(&mut module.types, params, results);
+    let args: Vec<_> = params.iter().map(|&ty| module.locals.add(ty)).collect();
+    let mut body = builder.func_body();
+    for ((&arg, &param), &target_param) in args.iter().zip(params).zip(&target_params) {
+        body.local_get(arg);
+        if param == EXTERNREF && target_param == NON_NULL_EXTERNREF {
+            body.ref_as_non_null();
+        }
+    }
+    body.call(target_id);
+
+    if results
+        .iter()
+        .zip(&target_results)
+        .any(|(&result, &target_result)| result == NON_NULL_EXTERNREF && target_result == EXTERNREF)
+    {
+        let result_locals: Vec<_> = target_results
+            .iter()
+            .map(|&ty| module.locals.add(ty))
+            .collect();
+        for &local in result_locals.iter().rev() {
+            body.local_set(local);
+        }
+        for ((&local, &result), &target_result) in
+            result_locals.iter().zip(results).zip(&target_results)
+        {
+            body.local_get(local);
+            if result == NON_NULL_EXTERNREF && target_result == EXTERNREF {
+                body.ref_as_non_null();
+            }
+        }
+    }
+    builder.local_func(args)
 }
 
 fn function_offset(local_fn: &LocalFunction) -> Option<u32> {

--- a/crates/lib/src/signature.rs
+++ b/crates/lib/src/signature.rs
@@ -202,6 +202,10 @@ impl<'a> Function<'a> {
     // **NB.** Keep synced with the `declare_function!()` macro below.
     pub const CUSTOM_SECTION_NAME: &'static str = "__externrefs";
 
+    /// Name of the supplementary section marking non-null `externref` args / return types.
+    /// Records use the same format as [`Self::CUSTOM_SECTION_NAME`].
+    pub const NON_NULL_CUSTOM_SECTION_NAME: &'static str = "__externrefs_non_null";
+
     /// Computes length of a custom section for this function signature.
     #[doc(hidden)]
     pub const fn custom_section_len(&self) -> usize {
@@ -260,6 +264,21 @@ impl<'a> Function<'a> {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! declare_function {
+    ($signature:expr, non_null = $non_null:expr) => {
+        $crate::declare_function!($signature);
+        const _: () = {
+            const FUNCTION: $crate::Function = $signature;
+            const NON_NULL_FUNCTION: $crate::Function = $crate::Function {
+                kind: FUNCTION.kind,
+                name: FUNCTION.name,
+                externrefs: $non_null,
+            };
+
+            #[cfg_attr(target_arch = "wasm32", unsafe(link_section = "__externrefs_non_null"))]
+            static NON_NULL_DATA_SECTION: [u8; NON_NULL_FUNCTION.custom_section_len()] =
+                NON_NULL_FUNCTION.custom_section();
+        };
+    };
     ($signature:expr) => {
         const _: () = {
             const FUNCTION: $crate::Function = $signature;

--- a/crates/lib/tests/processor.rs
+++ b/crates/lib/tests/processor.rs
@@ -2,7 +2,11 @@
 
 use std::path::Path;
 
-use externref::{BitSlice, Function, FunctionKind, processor::Processor};
+use assert_matches::assert_matches;
+use externref::{
+    BitSlice, Function, FunctionKind,
+    processor::{Error, Processor},
+};
 use walrus::{ExportItem, ImportKind, Module, RawCustomSection, RefType, ValType};
 
 const EXTERNREF: ValType = ValType::Ref(RefType::EXTERNREF);
@@ -87,6 +91,121 @@ fn basic_module() {
     // Check that the module is well-formed by converting it to bytes and back.
     let module_bytes = module.emit_wasm();
     Module::from_buffer(&module_bytes).unwrap();
+}
+
+#[test]
+fn non_null_import_result() {
+    const NON_NULL_RESULT: Function<'static> = Function {
+        kind: FunctionKind::Import("arena"),
+        name: "alloc",
+        externrefs: BitSlice::builder::<1>(3).with_set_bit(2).build(),
+    };
+    const NON_NULL_BYTES: [u8; NON_NULL_RESULT.custom_section_len()] =
+        NON_NULL_RESULT.custom_section();
+
+    let module = wat::parse_file(simple_module_path()).unwrap();
+    let mut module = Module::from_buffer(&module).unwrap();
+    add_basic_custom_section(&mut module);
+    module.customs.add(RawCustomSection {
+        name: Function::NON_NULL_CUSTOM_SECTION_NAME.to_owned(),
+        data: NON_NULL_BYTES.to_vec(),
+    });
+
+    Processor::default().process(&mut module).unwrap();
+
+    let import_id = module.imports.find("arena", "alloc").unwrap();
+    let ImportKind::Function(function_id) = module.imports.get(import_id).kind else {
+        panic!("expected a function import");
+    };
+    let function_type = module.types.get(module.funcs.get(function_id).ty());
+    assert_eq!(function_type.params(), [EXTERNREF, ValType::I32]);
+    assert_eq!(
+        function_type.results(),
+        [ValType::Ref(RefType {
+            nullable: false,
+            ..RefType::EXTERNREF
+        })]
+    );
+    assert!(
+        module
+            .customs
+            .remove_raw(Function::CUSTOM_SECTION_NAME)
+            .is_none()
+    );
+    assert!(
+        module
+            .customs
+            .remove_raw(Function::NON_NULL_CUSTOM_SECTION_NAME)
+            .is_none()
+    );
+
+    let module_bytes = module.emit_wasm();
+    Module::from_buffer(&module_bytes).unwrap();
+}
+
+#[test]
+fn non_null_metadata_requires_primary_section() {
+    let mut module = Module::default();
+    module.customs.add(RawCustomSection {
+        name: Function::NON_NULL_CUSTOM_SECTION_NAME.to_owned(),
+        data: vec![],
+    });
+
+    assert_matches!(
+        Processor::default().process(&mut module),
+        Err(Error::MissingExternrefSection)
+    );
+}
+
+#[test]
+fn non_null_metadata_rejects_non_resource_args() {
+    const INVALID: Function<'static> = Function {
+        kind: FunctionKind::Import("arena"),
+        name: "alloc",
+        externrefs: BitSlice::builder::<1>(3).with_set_bit(1).build(),
+    };
+    const BYTES: [u8; INVALID.custom_section_len()] = INVALID.custom_section();
+
+    let module = wat::parse_file(simple_module_path()).unwrap();
+    let mut module = Module::from_buffer(&module).unwrap();
+    add_basic_custom_section(&mut module);
+    module.customs.add(RawCustomSection {
+        name: Function::NON_NULL_CUSTOM_SECTION_NAME.to_owned(),
+        data: BYTES.to_vec(),
+    });
+
+    assert_matches!(
+        Processor::default().process(&mut module),
+        Err(Error::InvalidNonNullSignature { module: Some(module), name })
+            if module == "arena" && name == "alloc"
+    );
+}
+
+#[test]
+fn non_null_metadata_rejects_wrong_arity() {
+    const INVALID: Function<'static> = Function {
+        kind: FunctionKind::Import("arena"),
+        name: "alloc",
+        externrefs: BitSlice::builder::<1>(2).with_set_bit(0).build(),
+    };
+    const BYTES: [u8; INVALID.custom_section_len()] = INVALID.custom_section();
+
+    let module = wat::parse_file(simple_module_path()).unwrap();
+    let mut module = Module::from_buffer(&module).unwrap();
+    add_basic_custom_section(&mut module);
+    module.customs.add(RawCustomSection {
+        name: Function::NON_NULL_CUSTOM_SECTION_NAME.to_owned(),
+        data: BYTES.to_vec(),
+    });
+
+    assert_matches!(
+        Processor::default().process(&mut module),
+        Err(Error::UnexpectedArity {
+            expected_arity: 2,
+            real_arity: 3,
+            ..
+        })
+    );
 }
 
 #[test]

--- a/crates/macro/src/externref.rs
+++ b/crates/macro/src/externref.rs
@@ -117,13 +117,13 @@ impl SimpleResourceKind {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ResourceKind {
-    Simple(SimpleResourceKind),
+    NonNull(SimpleResourceKind),
     Option(SimpleResourceKind),
 }
 
 impl From<SimpleResourceKind> for ResourceKind {
     fn from(simple: SimpleResourceKind) -> Self {
-        Self::Simple(simple)
+        Self::NonNull(simple)
     }
 }
 
@@ -163,8 +163,12 @@ impl ResourceKind {
 
     fn simple_kind(self) -> SimpleResourceKind {
         match self {
-            Self::Simple(simple) | Self::Option(simple) => simple,
+            Self::NonNull(simple) | Self::Option(simple) => simple,
         }
+    }
+
+    fn is_non_null(self) -> bool {
+        !matches!(self, Self::Option(_))
     }
 
     fn initialize_for_export(self, arg: &Ident, cr: &Path) -> TokenStream {
@@ -177,7 +181,7 @@ impl ResourceKind {
                 };
                 quote!(#cr::Resource::new(#arg) #method_call)
             }
-            Self::Simple(_) => {
+            Self::NonNull(_) => {
                 let ref_token = match self.simple_kind() {
                     SimpleResourceKind::Owned => None,
                     SimpleResourceKind::Ref => Some(quote!(&)),
@@ -190,7 +194,8 @@ impl ResourceKind {
 
     fn prepare_for_import(self, arg: &Ident, cr: &Path) -> TokenStream {
         let arg = match self {
-            Self::Simple(_) => quote!(core::option::Option::Some(#arg)),
+            Self::NonNull(_) => quote!(core::option::Option::Some(#arg)),
+            Self::Option(SimpleResourceKind::MutRef) => quote!(#arg.as_deref()),
             Self::Option(_) => quote!(#arg),
         };
 
@@ -292,14 +297,20 @@ impl Function {
         } else {
             quote!(#cr::FunctionKind::Export)
         };
-        let externrefs = self.create_externrefs();
+        let externrefs = self.create_externrefs(false);
+        let has_non_null = self.resource_args.values().any(|kind| kind.is_non_null())
+            || matches!(self.return_type, ReturnType::Resource(kind) if kind.is_non_null());
+        let non_null = has_non_null.then(|| {
+            let non_null = self.create_externrefs(true);
+            quote!(, non_null = #non_null)
+        });
 
         quote! {
             #cr::declare_function!(#cr::Function {
                 kind: #kind,
                 name: #name,
                 externrefs: #externrefs,
-            });
+            } #non_null);
         }
     }
 
@@ -415,7 +426,7 @@ impl Function {
         (wrapper, new_ident)
     }
 
-    fn create_externrefs(&self) -> impl ToTokens {
+    fn create_externrefs(&self, non_null: bool) -> impl ToTokens {
         let cr = &self.crate_path;
         let args_and_return_type_count = if matches!(self.return_type, ReturnType::Default) {
             self.arg_count
@@ -424,13 +435,20 @@ impl Function {
         };
         let bytes = args_and_return_type_count.div_ceil(8);
 
-        let maybe_ret_idx = if matches!(self.return_type, ReturnType::Resource(_)) {
+        let has_ref_return = match self.return_type {
+            ReturnType::Resource(kind) => !non_null || kind.is_non_null(),
+            _ => false,
+        };
+        let maybe_ret_idx = if has_ref_return {
             Some(self.arg_count)
         } else {
             None
         };
 
-        let set_bits = self.resource_args.keys().copied();
+        let set_bits = self
+            .resource_args
+            .iter()
+            .filter_map(|(&idx, kind)| (!non_null || kind.is_non_null()).then_some(idx));
         #[cfg(test)] // sort keys in deterministic order for testing
         let set_bits = {
             let mut sorted: Vec<_> = set_bits.collect();
@@ -654,6 +672,121 @@ mod tests {
     use super::*;
 
     #[test]
+    fn declaring_non_null_signature() {
+        let mut export_fn: ItemFn = syn::parse_quote! {
+            pub extern "C" fn test_export(
+                sender: &mut Resource<Sender>,
+                buffer: Option<Resource<Buffer>>,
+                some_ptr: *const u8,
+            ) -> ResourceCopy<Sender> {
+                loop {}
+            }
+        };
+        let parsed = Function::new(&mut export_fn, &ExternrefAttrs::default()).unwrap();
+        let declaration = parsed.declare(None);
+        let declaration: syn::Item = syn::parse_quote!(#declaration);
+        let expected: syn::Item = syn::parse_quote! {
+            externref::declare_function!(externref::Function {
+                kind: externref::FunctionKind::Export,
+                name: "test_export",
+                externrefs: externref::BitSlice::builder::<1usize>(4usize)
+                    .with_set_bit(0usize)
+                    .with_set_bit(1usize)
+                    .with_set_bit(3usize)
+                    .build(),
+            }, non_null = externref::BitSlice::builder::<1usize>(4usize)
+                .with_set_bit(0usize)
+                .with_set_bit(3usize)
+                .build());
+        };
+        assert_eq!(declaration, expected, "{}", quote!(#declaration));
+    }
+
+    #[test]
+    fn non_null_resource_kinds() {
+        let cases: [(Type, SimpleResourceKind); 5] = [
+            (syn::parse_quote!(Resource<()>), SimpleResourceKind::Owned),
+            (syn::parse_quote!(&Resource<()>), SimpleResourceKind::Ref),
+            (
+                syn::parse_quote!(&mut Resource<()>),
+                SimpleResourceKind::MutRef,
+            ),
+            (
+                syn::parse_quote!(ResourceCopy<()>),
+                SimpleResourceKind::Owned,
+            ),
+            (syn::parse_quote!(Handle), SimpleResourceKind::Owned),
+        ];
+        for (ty, expected) in cases {
+            let kind = ResourceKind::from_type(&ty, Some(true)).unwrap();
+            assert_eq!(kind, Some(ResourceKind::NonNull(expected)));
+        }
+    }
+
+    #[test]
+    fn optional_resource_kinds() {
+        let cases: [(Type, SimpleResourceKind); 4] = [
+            (
+                syn::parse_quote!(Option<Resource<()>>),
+                SimpleResourceKind::Owned,
+            ),
+            (
+                syn::parse_quote!(Option<&Resource<()>>),
+                SimpleResourceKind::Ref,
+            ),
+            (
+                syn::parse_quote!(Option<&mut Resource<()>>),
+                SimpleResourceKind::MutRef,
+            ),
+            (syn::parse_quote!(Option<Handle>), SimpleResourceKind::Owned),
+        ];
+        for (ty, expected) in cases {
+            let kind = ResourceKind::from_type(&ty, Some(true)).unwrap();
+            assert_eq!(kind, Some(ResourceKind::Option(expected)));
+        }
+    }
+
+    #[test]
+    fn resource_nullability_follows_rust_types() {
+        let types: [Type; 6] = [
+            syn::parse_quote!(Resource<()>),
+            syn::parse_quote!(&Resource<()>),
+            syn::parse_quote!(&mut Resource<()>),
+            syn::parse_quote!(ResourceCopy<()>),
+            syn::parse_quote!(&ResourceCopy<()>),
+            syn::parse_quote!(&mut ResourceCopy<()>),
+        ];
+        for resource_type in types {
+            for optional in [false, true] {
+                let rust_type: Type = if optional {
+                    syn::parse_quote!(Option<#resource_type>)
+                } else {
+                    resource_type.clone()
+                };
+                let mut signature: Signature = syn::parse_quote! {
+                    fn round_trip(value: #rust_type) -> #rust_type
+                };
+                let parsed =
+                    Function::from_sig(&mut signature, None, &ExternrefAttrs::default(), None)
+                        .unwrap();
+                let metadata = parsed.create_externrefs(true);
+                let metadata: Expr = syn::parse_quote!(#metadata);
+                let expected: Expr = if optional {
+                    syn::parse_quote!(externref::BitSlice::builder::<1usize>(2usize).build())
+                } else {
+                    syn::parse_quote! {
+                        externref::BitSlice::builder::<1usize>(2usize)
+                            .with_set_bit(0usize)
+                            .with_set_bit(1usize)
+                            .build()
+                    }
+                };
+                assert_eq!(metadata, expected, "{}", quote!(#signature));
+            }
+        }
+    }
+
+    #[test]
     fn declaring_signature_for_export() {
         let mut export_fn: ItemFn = syn::parse_quote! {
             pub extern "C" fn test_export(
@@ -677,7 +810,10 @@ mod tests {
                     .with_set_bit(0usize)
                     .with_set_bit(1usize)
                     .build(),
-            });
+            }, non_null = externref::BitSlice::builder::<1usize>(3usize)
+                .with_set_bit(0usize)
+                .with_set_bit(1usize)
+                .build());
         };
         assert_eq!(declaration, expected, "{}", quote!(#declaration));
     }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -98,6 +98,22 @@ impl ExternrefAttrs {
 /// - `#[resource]`, `#[resource = true]` or `#[resource(true)]` mark an arg / return type as a resource.
 /// - `#[resource = false]` or `#[resource(false)]` mark an arg / return type as a non-resource.
 ///
+/// # Nullability
+///
+/// Nullability is determined by the Rust type for both arguments and results:
+///
+/// - `Resource<T>`, `&Resource<T>` and `&mut Resource<T>` become `(ref extern)`.
+/// - Their `Option<_>` forms become nullable `externref` (`(ref null extern)`).
+/// - `ResourceCopy` and resource aliases marked with `#[resource]` follow the same rules.
+///   The `Option` wrapper must appear explicitly in the signature.
+///
+/// No nullability attribute is required. For example, declare the `cast` import from
+/// `wasm:js-string` as `fn cast(value: Option<&Resource<()>>) -> Resource<()>` to obtain
+/// `(externref) -> (ref extern)`. Pass a non-null resource using `Some(&resource)`.
+///
+/// Non-null metadata requires an updated `externref` processor or CLI. If optimizing the
+/// processed module with Binaryen, pass `--enable-gc` to preserve non-null reference types.
+///
 /// # Attributes
 ///
 /// The `externref` macro supports attributes specified in parentheses after the macro

--- a/e2e-tests/src/imports.rs
+++ b/e2e-tests/src/imports.rs
@@ -11,7 +11,22 @@ unsafe extern "C" {
         message_len: usize,
     ) -> Resource<Bytes>;
 
+    pub(crate) fn send_message_non_null(
+        sender: &mut Resource<Sender>,
+        message_ptr: *const u8,
+        message_len: usize,
+    ) -> Resource<Bytes>;
+
     pub(crate) fn message_len(bytes: Option<&Resource<Bytes>>) -> usize;
+
+    pub(crate) fn round_trip(
+        value: Resource<Sender>,
+        reference: &Resource<Sender>,
+        mut_reference: &mut Resource<Sender>,
+        optional_value: Option<Resource<Sender>>,
+        optional_reference: Option<&Resource<Sender>>,
+        optional_mut_reference: Option<&mut Resource<Sender>>,
+    ) -> Option<Resource<Sender>>;
 
     /// Inspects the pointer to the `Resource` rather than using the resource itself.
     /// This is unusual but valid resource usage.
@@ -39,3 +54,9 @@ unsafe extern "C" {
     pub(crate) fn inspect_message(#[resource = false] bytes: MessageCopy);
 }
 // ANCHOR_END: imports_copy
+
+#[externref::externref(stubs)]
+#[link(wasm_import_module = "wasm:js-string")]
+unsafe extern "C" {
+    pub(crate) fn cast(value: Option<&Resource<()>>) -> Resource<()>;
+}

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -155,3 +155,38 @@ pub extern "C" fn test_returning_resource(
     }
     sender
 }
+
+#[externref]
+pub extern "C" fn test_non_null(mut sender: Resource<Sender>) -> Resource<Sender> {
+    let message = "non-null";
+    unsafe {
+        imports::send_message_non_null(&mut sender, message.as_ptr(), message.len());
+    }
+    sender
+}
+
+#[externref]
+pub extern "C" fn test_js_string_cast(value: Option<Resource<()>>) -> Resource<()> {
+    unsafe { imports::cast(value.as_ref()) }
+}
+
+#[externref]
+pub extern "C" fn test_resource_types(
+    value: Resource<Sender>,
+    reference: &Resource<Sender>,
+    mut_reference: &mut Resource<Sender>,
+    optional_value: Option<Resource<Sender>>,
+    optional_reference: Option<&Resource<Sender>>,
+    optional_mut_reference: Option<&mut Resource<Sender>>,
+) -> Option<Resource<Sender>> {
+    unsafe {
+        imports::round_trip(
+            value,
+            reference,
+            mut_reference,
+            optional_value,
+            optional_reference,
+            optional_mut_reference,
+        )
+    }
+}

--- a/e2e-tests/tests/integration/compile.rs
+++ b/e2e-tests/tests/integration/compile.rs
@@ -74,7 +74,13 @@ fn optimize_wasm(wasm_module: Vec<u8>, temp_dir: &Path) -> Vec<u8> {
     let output_path = temp_dir.join("out.wasm");
     let mut command = Command::new("wasm-opt");
     command
-        .args(["-Os", "--enable-mutable-globals", "--strip-debug", "-o"])
+        .args([
+            "-Os",
+            "--enable-mutable-globals",
+            "--enable-gc",
+            "--strip-debug",
+            "-o",
+        ])
         .arg(&output_path)
         .arg(&module_path)
         .stderr(Stdio::piped());

--- a/e2e-tests/tests/integration/main.rs
+++ b/e2e-tests/tests/integration/main.rs
@@ -109,10 +109,10 @@ impl Data {
 
 fn send_message(
     mut ctx: Caller<'_, Data>,
-    resource: Option<Rooted<ExternRef>>,
+    resource: Rooted<ExternRef>,
     buffer_ptr: u32,
     buffer_len: u32,
-) -> wasmtime::Result<Option<Rooted<ExternRef>>> {
+) -> wasmtime::Result<Rooted<ExternRef>> {
     let memory = ctx
         .get_export("memory")
         .and_then(Extern::into_memory)
@@ -125,7 +125,6 @@ fn send_message(
     let buffer = String::from_utf8(buffer).context("buffer is not utf-8")?;
 
     let sender = resource
-        .context("null reference passed to host")?
         .data(&ctx)?
         .context("null reference")?
         .downcast_ref::<HostSender>()
@@ -133,7 +132,7 @@ fn send_message(
     assert!(ctx.data().senders.contains(&sender.key));
 
     let bytes = Box::<str>::from(buffer);
-    ExternRef::new(&mut ctx, bytes).map(Some)
+    ExternRef::new(&mut ctx, bytes)
 }
 
 fn message_len(
@@ -234,6 +233,39 @@ fn create_linker(engine: &Engine) -> Linker<Data> {
         .func_wrap("test", "send_message_copy", send_message)
         .unwrap();
     linker
+        .func_wrap("test", "send_message_non_null", send_message)
+        .unwrap();
+    linker
+        .func_wrap(
+            "test",
+            "round_trip",
+            |_value: Rooted<ExternRef>,
+             _reference: Rooted<ExternRef>,
+             _mut_reference: Rooted<ExternRef>,
+             optional_value: Option<Rooted<ExternRef>>,
+             optional_reference: Option<Rooted<ExternRef>>,
+             optional_mut_reference: Option<Rooted<ExternRef>>| {
+                assert_eq!(optional_value.is_some(), optional_reference.is_some());
+                assert_eq!(optional_value.is_some(), optional_mut_reference.is_some());
+                optional_value
+            },
+        )
+        .unwrap();
+    linker
+        .func_wrap(
+            "wasm:js-string",
+            "cast",
+            |ctx: Caller<'_, Data>, resource: Option<Rooted<ExternRef>>| {
+                let resource = resource.context("null string")?;
+                let data = resource.data(&ctx)?.context("null reference")?;
+                if !data.is::<Box<str>>() {
+                    return Err(wasmtime::format_err!("not a string"));
+                }
+                Ok(resource)
+            },
+        )
+        .unwrap();
+    linker
         .func_wrap("test", "message_len", message_len)
         .unwrap();
     linker
@@ -302,7 +334,7 @@ fn assert_tracing_output(storage: &Storage) {
     let spans = storage.scan_spans();
     let process_span = spans.single(&name(eq("process")));
     let matches =
-        level(Level::INFO) & message(eq("parsed custom section")) & field("functions.len", 9_u64);
+        level(Level::INFO) & message(eq("parsed custom section")) & field("functions.len", 15_u64);
     process_span.scan_events().single(&matches);
 
     let patch_imports_span = spans.single(&name(eq("patch_imports")));
@@ -328,8 +360,10 @@ fn assert_tracing_output(storage: &Storage) {
 
     let transformed_imports = storage.all_spans().filter_map(|span| {
         if span.metadata().name() == "transform_import" {
-            assert_eq!(span["module"].as_str(), Some("test"));
-            span.value("name")?.as_str()
+            Some((
+                span.value("module")?.as_str()?,
+                span.value("name")?.as_str()?,
+            ))
         } else {
             None
         }
@@ -337,7 +371,14 @@ fn assert_tracing_output(storage: &Storage) {
     let transformed_imports: HashSet<_> = transformed_imports.collect();
     assert_eq!(
         transformed_imports,
-        HashSet::from_iter(["send_message", "send_message_copy", "message_len"])
+        HashSet::from_iter([
+            ("test", "send_message"),
+            ("test", "send_message_copy"),
+            ("test", "send_message_non_null"),
+            ("test", "message_len"),
+            ("test", "round_trip"),
+            ("wasm:js-string", "cast"),
+        ])
     );
 
     let transformed_exports = storage.all_spans().filter_map(|span| {
@@ -363,7 +404,7 @@ fn assert_tracing_output(storage: &Storage) {
     );
     assert_eq!(
         transformed_exports.len(),
-        4 + contains_export as usize + contains_export_with_casts as usize,
+        7 + contains_export as usize + contains_export_with_casts as usize,
         "{transformed_exports:?}"
     );
 }
@@ -398,14 +439,13 @@ fn returning_resource_from_guest(profile: CompilationProfile) {
 
     let (instance, mut store, sender) = init_sender(profile);
     let test_fn = instance
-        .get_typed_func::<Option<Rooted<ExternRef>>, Option<Rooted<ExternRef>>>(
+        .get_typed_func::<Option<Rooted<ExternRef>>, Rooted<ExternRef>>(
             &mut store,
             "test_returning_resource",
         )
         .unwrap();
     let returned_sender = test_fn.call(&mut store, Some(sender)).unwrap();
 
-    let returned_sender = returned_sender.expect("returned null");
     let returned_sender = returned_sender.data(&store).unwrap().expect("no data");
     let returned_sender = returned_sender.downcast_ref::<HostSender>().unwrap();
     assert_eq!(returned_sender.key, "sender");
@@ -429,6 +469,124 @@ fn returning_resource_from_guest(profile: CompilationProfile) {
 }
 
 #[test_casing(4, CompilationProfile::ALL)]
+fn non_null_imports_and_exports(profile: CompilationProfile) {
+    enable_tracing();
+
+    let (instance, mut store, sender) = init_sender(profile);
+    let function_type = instance
+        .get_func(&mut store, "test_non_null")
+        .unwrap()
+        .ty(&store);
+    assert!(matches!(
+        function_type.params().next().unwrap(),
+        wasmtime::ValType::Ref(ref_type) if !ref_type.is_nullable()
+    ));
+    assert!(matches!(
+        function_type.results().next().unwrap(),
+        wasmtime::ValType::Ref(ref_type) if !ref_type.is_nullable()
+    ));
+
+    let test_fn = instance
+        .get_typed_func::<Rooted<ExternRef>, Rooted<ExternRef>>(&mut store, "test_non_null")
+        .unwrap();
+    let returned = test_fn.call(&mut store, sender).unwrap();
+    let returned = returned.data(&store).unwrap().unwrap();
+    assert_eq!(returned.downcast_ref::<HostSender>().unwrap().key, "sender");
+
+    let externrefs = instance.get_table(&mut store, "externrefs").unwrap();
+    assert_refs(&mut store, &externrefs, false, &[false]);
+    assert_eq!(store.data().dropped.len(), 2);
+    store.data().assert_drops(&store, &["non-null"].into());
+}
+
+#[test_casing(4, CompilationProfile::ALL)]
+fn non_null_js_string_cast(profile: CompilationProfile) {
+    enable_tracing();
+
+    let (instance, mut store, sender) = init_sender(profile);
+    let test_fn = instance
+        .get_typed_func::<Option<Rooted<ExternRef>>, Rooted<ExternRef>>(
+            &mut store,
+            "test_js_string_cast",
+        )
+        .unwrap();
+    let string = ExternRef::new(&mut store, Box::<str>::from("js-string")).unwrap();
+    let returned = test_fn.call(&mut store, Some(string)).unwrap();
+    let returned = returned.data(&store).unwrap().unwrap();
+    assert_eq!(
+        returned.downcast_ref::<Box<str>>().unwrap().as_ref(),
+        "js-string"
+    );
+
+    let externrefs = instance.get_table(&mut store, "externrefs").unwrap();
+    for index in 0..externrefs.size(&store) {
+        assert_matches!(
+            externrefs.get(&mut store, index).unwrap(),
+            Ref::Extern(None)
+        );
+    }
+    assert_eq!(store.data().dropped.len(), 2);
+    store.data().assert_drops(&store, &["js-string"].into());
+    assert!(test_fn.call(&mut store, None).is_err());
+    assert!(test_fn.call(&mut store, Some(sender)).is_err());
+}
+
+#[test_casing(4, CompilationProfile::ALL)]
+fn resource_type_nullability(profile: CompilationProfile) {
+    enable_tracing();
+
+    let (instance, mut store, sender) = init_sender(profile);
+    let function_type = instance
+        .get_func(&mut store, "test_resource_types")
+        .unwrap()
+        .ty(&store);
+    let params: Vec<_> = function_type
+        .params()
+        .map(|ty| match ty {
+            wasmtime::ValType::Ref(ref_type) => ref_type.is_nullable(),
+            other => panic!("expected externref, got {other}"),
+        })
+        .collect();
+    assert_eq!(params, [false, false, false, true, true, true]);
+    assert!(matches!(
+        function_type.results().next().unwrap(),
+        wasmtime::ValType::Ref(ref_type) if ref_type.is_nullable()
+    ));
+
+    let test_fn = instance
+        .get_typed_func::<(
+            Rooted<ExternRef>,
+            Rooted<ExternRef>,
+            Rooted<ExternRef>,
+            Option<Rooted<ExternRef>>,
+            Option<Rooted<ExternRef>>,
+            Option<Rooted<ExternRef>>,
+        ), Option<Rooted<ExternRef>>>(&mut store, "test_resource_types")
+        .unwrap();
+    for optional in [Some(sender), None] {
+        let returned = test_fn
+            .call(
+                &mut store,
+                (sender, sender, sender, optional, optional, optional),
+            )
+            .unwrap();
+        assert_eq!(returned.is_some(), optional.is_some());
+        if let Some(returned) = returned {
+            let data = returned.data(&store).unwrap().unwrap();
+            assert_eq!(data.downcast_ref::<HostSender>().unwrap().key, "sender");
+        }
+
+        let externrefs = instance.get_table(&mut store, "externrefs").unwrap();
+        for index in 0..externrefs.size(&store) {
+            assert_matches!(
+                externrefs.get(&mut store, index).unwrap(),
+                Ref::Extern(None)
+            );
+        }
+    }
+}
+
+#[test_casing(4, CompilationProfile::ALL)]
 fn resource_copies(profile: CompilationProfile) {
     enable_tracing();
 
@@ -437,9 +595,9 @@ fn resource_copies(profile: CompilationProfile) {
     store.data_mut().externrefs = Some(externrefs);
 
     let test_fn = instance
-        .get_typed_func::<Option<Rooted<ExternRef>>, ()>(&mut store, "test_export_with_copies")
+        .get_typed_func::<Rooted<ExternRef>, ()>(&mut store, "test_export_with_copies")
         .unwrap();
-    test_fn.call(&mut store, Some(sender)).unwrap();
+    test_fn.call(&mut store, sender).unwrap();
 
     let externrefs = instance.get_table(&mut store, "externrefs").unwrap();
     // We allocate 2 copied buffers: one via `-> ResourceCopy` and another by leaking the resource


### PR DESCRIPTION
Fixes https://github.com/slowli/externref/issues/299
### Added

- Support non-null WASM reference types (`(ref extern)`) on imported and exported
  function arguments and results, including JS string builtins.

Rust types **Resource<T>, &Resource<T> and &mut Resource<T>** are preprocessed into **(ref extern)** (new type introduced by this PR)
Rust types **Option<Resource<T>>, Option<&Resource<T>> and Option<&mut Resource<T>>** are preprocessed into **(ref null extern)** (aka. externref, current behavior)

### Changed

- **Breaking:** Derive WASM nullability from Rust types. `Resource`, `ResourceCopy` and
  their references now use `(ref extern)`; `Option` forms use `(ref null extern)`.

### Fixed

- Handle optional mutable resource references in generated import wrappers.
- Recognize debug import guards after argument spills in the stack prologue.
